### PR TITLE
Add deleteFromRemovedCollaterals function upon last trove closed in removed branch

### DIFF
--- a/contracts/script/DeployLiquity2.s.sol
+++ b/contracts/script/DeployLiquity2.s.sol
@@ -27,6 +27,9 @@ import "src/StabilityPool.sol";
 import "src/PriceFeeds/WETHPriceFeed.sol";
 // import "src/PriceFeeds/WSTETHPriceFeed.sol";
 import "src/PriceFeeds/RETHPriceFeed.sol";
+import "src/PriceFeeds/TBTCPriceFeed.sol";
+import "src/PriceFeeds/FBTCPriceFeed.sol";
+import "src/PriceFeeds/SAGAPriceFeed.sol";
 import "src/CollateralRegistry.sol";
 import "test/TestContracts/PriceFeedTestnet.sol";
 import "test/TestContracts/MetadataDeployment.sol";
@@ -83,10 +86,21 @@ contract DeployLiquity2Script is DeployGovernance, UniPriceConverter, StdCheats,
     address SAGA_ADDRESS = 0xA19377761FED745723B90993988E04d641c2CfFE;
     address ETH_ORACLE_ADDRESS = 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419;
     address RETH_ORACLE_ADDRESS = 0x536218f9E9Eb48863970252233c8F271f554C2d0;
-    address STETH_ORACLE_ADDRESS = 0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8;
+    // address STETH_ORACLE_ADDRESS = 0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8;
+    // TODO: Change these values
+    address TBTC_ORACLE_ADDRESS = 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419;
+    address FBTC_ORACLE_ADDRESS = 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419;
+    address BTC_ORACLE_ADDRESS = 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419;
+    address SAGA_ORACLE_ADDRESS = 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419;
+    ///////////////////////////////
     uint256 ETH_USD_STALENESS_THRESHOLD = 24 hours;
-    uint256 STETH_USD_STALENESS_THRESHOLD = 24 hours;
+    // uint256 STETH_USD_STALENESS_THRESHOLD = 24 hours;
     uint256 RETH_ETH_STALENESS_THRESHOLD = 48 hours;
+    // TODO: Change these values
+    uint256 TBTC_ETH_STALENESS_THRESHOLD = 24 hours;
+    uint256 FBTC_ETH_STALENESS_THRESHOLD = 24 hours;
+    uint256 BTC_USD_STALENESS_THRESHOLD = 24 hours;
+    uint256 SAGA_USD_STALENESS_THRESHOLD = 24 hours;
 
     // V1
     address LQTY_ADDRESS = 0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D;
@@ -828,29 +842,46 @@ contract DeployLiquity2Script is DeployGovernance, UniPriceConverter, StdCheats,
         internal
         returns (IPriceFeed)
     {
-        if (block.chainid == 1 && !useTestnetPriceFeeds) {
-            // mainnet
+        if (block.chainid == 5464 && !useTestnetPriceFeeds) {
+            // Saga
             // ETH
             if (_collTokenAddress == address(WETH)) {
                 return new WETHPriceFeed(ETH_ORACLE_ADDRESS, ETH_USD_STALENESS_THRESHOLD, _borroweOperationsAddress);
-            // } else if (_collTokenAddress == WSTETH_ADDRESS) {
-            //     // wstETH
-            //     return new WSTETHPriceFeed(
-            //         ETH_ORACLE_ADDRESS,
-            //         STETH_ORACLE_ADDRESS,
-            //         WSTETH_ADDRESS,
-            //         ETH_USD_STALENESS_THRESHOLD,
-            //         STETH_USD_STALENESS_THRESHOLD,
-            //         _borroweOperationsAddress
-            //     );
+            } else if (_collTokenAddress == RETH_ADDRESS) {
+                // rETH
+                return new RETHPriceFeed(
+                    deployer,
+                    RETH_ORACLE_ADDRESS,
+                    RETH_ETH_STALENESS_THRESHOLD
+                );
+            } else if (_collTokenAddress == TBTC_ADDRESS) {
+                // tBTC
+                return new TBTCPriceFeed(
+                    deployer,
+                    TBTC_ORACLE_ADDRESS,
+                    TBTC_ETH_STALENESS_THRESHOLD,
+                    BTC_ORACLE_ADDRESS,
+                    BTC_USD_STALENESS_THRESHOLD
+                );
+            } else if (_collTokenAddress == FBTC_ADDRESS) {
+                // FBTC
+                return new FBTCPriceFeed(
+                    deployer,
+                    FBTC_ORACLE_ADDRESS,
+                    FBTC_ETH_STALENESS_THRESHOLD,
+                    BTC_ORACLE_ADDRESS,
+                    BTC_USD_STALENESS_THRESHOLD
+                );
+            } else if (_collTokenAddress == SAGA_ADDRESS) {
+                // SAGA
+                return new SAGAPriceFeed(
+                    deployer,
+                    SAGA_ORACLE_ADDRESS,
+                    SAGA_USD_STALENESS_THRESHOLD
+                );
+            } else {
+                revert("Invalid collateral token");
             }
-            // RETH
-            assert(_collTokenAddress == RETH_ADDRESS);
-            return IPriceFeed(address(new RETHPriceFeed(
-                deployer,
-                RETH_ORACLE_ADDRESS,
-                RETH_ETH_STALENESS_THRESHOLD
-            )));
         }
 
         // Sepolia

--- a/contracts/src/CollateralRegistry.sol
+++ b/contracts/src/CollateralRegistry.sol
@@ -458,7 +458,7 @@ contract CollateralRegistry is ICollateralRegistry {
     // }
 
     // A replacement to `deleteFromRemovedCollaterals` function.
-    // Anyone can call this function which deletes any dead branches from removed collaterals list.
+    // Anyone can call this function which deletes first dead branch found in removed collaterals list.
     function cleanRemovedCollaterals() external {
         for (uint256 i; i < removedBranchIds.length; i++) {
             uint256 branchId = removedBranchIds[i];
@@ -466,6 +466,7 @@ contract CollateralRegistry is ICollateralRegistry {
             if (troveManager.getTroveIdsCount() == 0) {
                 _permanentlyDeleteFromRemovedCollaterals(i);
                 emit CollateralDeleted(branchId);
+                break;
             }
         }
     }

--- a/contracts/src/CollateralRegistry.sol
+++ b/contracts/src/CollateralRegistry.sol
@@ -440,20 +440,33 @@ contract CollateralRegistry is ICollateralRegistry {
 
     // Only trove manager can call this function
     // This is called in _closeTrove() in TroveManager.sol only once last trove is closed
-    function deleteFromRemovedCollaterals(uint256 _branchId) external {
-        uint256 index = _removedBranchIdsIndex[_branchId];
-        ITroveManager troveManager = getRemovedTroveManager(index);
+    // function deleteFromRemovedCollaterals(uint256 _branchId) external {
+    //     uint256 index = _removedBranchIdsIndex[_branchId];
+    //     ITroveManager troveManager = getRemovedTroveManager(index);
 
-        require(_branchId == removedBranchIds[index], "CollateralRegistry: Wrong branchId");
-        require(msg.sender == address(troveManager), "CollateralRegistry: Only trove manager can call this function");
-        // An extra check to ensure that the trove manager has no troves left.
-        // This may prove to be redundant and can be removed in the future.
-        require(troveManager.getTroveIdsCount() == 0, "CollateralRegistry: Trove manager has troves");
+    //     require(_branchId == removedBranchIds[index], "CollateralRegistry: Wrong branchId");
+    //     require(msg.sender == address(troveManager), "CollateralRegistry: Only trove manager can call this function");
+    //     // An extra check to ensure that the trove manager has no troves left.
+    //     // This may prove to be redundant and can be removed in the future.
+    //     require(troveManager.getTroveIdsCount() == 0, "CollateralRegistry: Trove manager has troves");
 
-        // remove collateral from removed collateral tokens and trove managers lists
-        _permanentlyDeleteFromRemovedCollaterals(index);
+    //     // remove collateral from removed collateral tokens and trove managers lists
+    //     _permanentlyDeleteFromRemovedCollaterals(index);
 
-        // emit event
-        emit CollateralDeleted(_branchId);
+    //     // emit event
+    //     emit CollateralDeleted(_branchId);
+    // }
+
+    // A replacement to `deleteFromRemovedCollaterals` function.
+    // Anyone can call this function which deletes any dead branches from removed collaterals list.
+    function cleanRemovedCollaterals() external {
+        for (uint256 i; i < removedBranchIds.length; i++) {
+            uint256 branchId = removedBranchIds[i];
+            ITroveManager troveManager = getRemovedTroveManager(i);
+            if (troveManager.getTroveIdsCount() == 0) {
+                _permanentlyDeleteFromRemovedCollaterals(i);
+                emit CollateralDeleted(branchId);
+            }
+        }
     }
 }

--- a/contracts/src/Interfaces/ICollateralRegistry.sol
+++ b/contracts/src/Interfaces/ICollateralRegistry.sol
@@ -8,12 +8,14 @@ import "./ITroveManager.sol";
 
 interface ICollateralRegistry {
 
-    event CollateralAdded(address _token, address _troveManager, uint256 _branchId);
+    event CollateralAdded(uint256 _branchId, address _token, address _troveManager);
     event CollateralRemoved(uint256 _branchId, address _token, address _troveManager);
+    event CollateralDeleted(uint256 _branchId);
 
+    function isActiveCollateral(uint256 _branchId) external view returns (bool);
     function addCollateral(IERC20Metadata _token, ITroveManager _troveManager) external;
     function removeCollateral(uint256 _index) external;
-    function isActiveCollateral(uint256 _branchId) external view returns (bool);
+    function deleteFromRemovedCollaterals(uint256 _branchId) external;
 
     function baseRate() external view returns (uint256);
     function lastFeeOperationTime() external view returns (uint256);

--- a/contracts/src/Interfaces/ICollateralRegistry.sol
+++ b/contracts/src/Interfaces/ICollateralRegistry.sol
@@ -15,7 +15,8 @@ interface ICollateralRegistry {
     function isActiveCollateral(uint256 _branchId) external view returns (bool);
     function addCollateral(IERC20Metadata _token, ITroveManager _troveManager) external;
     function removeCollateral(uint256 _index) external;
-    function deleteFromRemovedCollaterals(uint256 _branchId) external;
+    // function deleteFromRemovedCollaterals(uint256 _branchId) external;
+    function cleanRemovedCollaterals() external;
 
     function baseRate() external view returns (uint256);
     function lastFeeOperationTime() external view returns (uint256);

--- a/contracts/src/Interfaces/ITroveManager.sol
+++ b/contracts/src/Interfaces/ITroveManager.sol
@@ -25,6 +25,7 @@ interface ITroveManager is ILiquityBase {
     function shutdownTime() external view returns (uint256);
 
     function branchId() external view returns (uint256);
+    function isActive() external view returns (bool);
 
     function troveNFT() external view returns (ITroveNFT);
     function stabilityPool() external view returns (IStabilityPool);

--- a/contracts/src/PriceFeeds/SAGAPriceFeed.sol
+++ b/contracts/src/PriceFeeds/SAGAPriceFeed.sol
@@ -6,8 +6,8 @@ pragma solidity 0.8.24;
 import "./TokenPriceFeedBase.sol";
 
 contract SAGAPriceFeed is TokenPriceFeedBase {
-   constructor(address _owner, address _arbUsdOracleAddress, uint256 _arbUsdStalenessThreshold)
-        TokenPriceFeedBase(_owner, _arbUsdOracleAddress, _arbUsdStalenessThreshold)
+   constructor(address _owner, address _sagaUsdOracleAddress, uint256 _sagaUsdStalenessThreshold)
+        TokenPriceFeedBase(_owner, _sagaUsdOracleAddress, _sagaUsdStalenessThreshold)
     {
         _fetchPricePrimary();
 

--- a/contracts/src/PriceFeeds/TokenPriceFeedBase.sol
+++ b/contracts/src/PriceFeeds/TokenPriceFeedBase.sol
@@ -5,10 +5,11 @@ pragma solidity 0.8.24;
 import "../Dependencies/Ownable.sol";
 import "../Dependencies/AggregatorV3Interface.sol";
 import "../BorrowerOperations.sol";
+import "../Interfaces/IPriceFeed.sol";
 
 // import "forge-std/console2.sol";
 
-abstract contract TokenPriceFeedBase is Ownable {
+abstract contract TokenPriceFeedBase is Ownable, IPriceFeed {
     // Determines where the PriceFeed sources data from. Possible states:
     // - primary: Uses the primary price calcuation, which depends on the specific feed
     // - lastGoodPrice: the last good price recorded by this PriceFeed.

--- a/contracts/src/PriceFeeds/tBTCPriceFeed.sol
+++ b/contracts/src/PriceFeeds/tBTCPriceFeed.sol
@@ -6,7 +6,7 @@ pragma solidity 0.8.24;
 import "./TokenPriceFeedBase.sol";
 import "../Dependencies/Constants.sol";
 
-contract tBTCPriceFeed is TokenPriceFeedBase {
+contract TBTCPriceFeed is TokenPriceFeedBase {
     Oracle public btcUsdOracle;
     Oracle public tBTCUsdOracle;
 

--- a/contracts/src/TroveManager.sol
+++ b/contracts/src/TroveManager.sol
@@ -242,6 +242,10 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
         return addressesRegistry.SCR();
     }
 
+    function isActive() public view returns (bool) {
+        return collateralRegistry.isActiveCollateral(branchId);
+    }
+
     function getTroveIdsCount() external view override returns (uint256) {
         return TroveIds.length;
     }
@@ -1240,7 +1244,7 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
     }
 
     function _requireActiveCollateral() internal view {
-        require(collateralRegistry.isActiveCollateral(branchId), "TroveManager: Collateral is not active");
+        require(isActive(), "TroveManager: Collateral is not active");
     }
 
     // --- Trove property getters ---
@@ -1532,10 +1536,12 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
         // assert(closedStatus == Status.closedByLiquidation || closedStatus == Status.closedByOwner);
 
         uint256 TroveIdsArrayLength = TroveIds.length;
+        bool isActiveStatus = isActive();
         // If branch has not been shut down, or it's a liquidation,
         // require at least 1 trove in the system
+        // ** NEW: **
         // TODO: Add check if branch has been removed, do we still require at least 1 trove in the system?
-        if (shutdownTime == 0 || closedStatus == Status.closedByLiquidation) {
+        if (isActiveStatus && (shutdownTime == 0 || closedStatus == Status.closedByLiquidation)) {
             _requireMoreThanOneTroveInSystem(TroveIdsArrayLength);
         }
 
@@ -1580,6 +1586,13 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
 
         // burn ERC721
         troveNFT.burn(_troveId);
+
+        // ** NEW: **
+        // If branch has been removed and there is no troves left in the system,
+        // permanently delete branch in CollateralRegistry
+        if (!isActiveStatus && TroveIdsArrayLength == 1) {
+            collateralRegistry.deleteFromRemovedCollaterals(branchId);
+        }
     }
 
     function onAdjustTroveInsideBatch(

--- a/contracts/src/TroveManager.sol
+++ b/contracts/src/TroveManager.sol
@@ -1541,7 +1541,7 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
         // require at least 1 trove in the system
         // ** NEW: **
         // TODO: Add check if branch has been removed, do we still require at least 1 trove in the system?
-        if (isActiveStatus && (shutdownTime == 0 || closedStatus == Status.closedByLiquidation)) {
+        if ((isActiveStatus && shutdownTime == 0) || closedStatus == Status.closedByLiquidation) {
             _requireMoreThanOneTroveInSystem(TroveIdsArrayLength);
         }
 
@@ -1590,9 +1590,9 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
         // ** NEW: **
         // If branch has been removed and there is no troves left in the system,
         // permanently delete branch in CollateralRegistry
-        if (!isActiveStatus && TroveIdsArrayLength == 1) {
-            collateralRegistry.deleteFromRemovedCollaterals(branchId);
-        }
+        // if (!isActiveStatus && TroveIdsArrayLength == 1) {
+        //     collateralRegistry.deleteFromRemovedCollaterals(branchId);
+        // }
     }
 
     function onAdjustTroveInsideBatch(

--- a/contracts/src/TroveManager.sol
+++ b/contracts/src/TroveManager.sol
@@ -1243,7 +1243,7 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
         }
     }
 
-    function _requireActiveCollateral() internal view {
+    function _requireIsActiveBranch() internal view {
         require(isActive(), "TroveManager: Collateral is not active");
     }
 
@@ -1268,7 +1268,7 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
         external
     {
         _requireCallerIsBorrowerOperations();
-        _requireActiveCollateral();
+        _requireIsActiveBranch();
 
         uint256 newStake = _computeNewStake(_troveChange.collIncrease);
 
@@ -1325,7 +1325,7 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
     ) external {
         _requireCallerIsBorrowerOperations();
         // assert(batchIds[batches[_batchAddress].arrayIndex] == _batchAddress);
-        _requireActiveCollateral();
+        _requireIsActiveBranch();
 
         uint256 newStake = _computeNewStake(_troveChange.collIncrease);
 

--- a/contracts/test/AnchoredInvariantsTest.t.sol
+++ b/contracts/test/AnchoredInvariantsTest.t.sol
@@ -20,10 +20,10 @@ contract AnchoredInvariantsTest is Logging, BaseInvariantTest, BaseMultiCollater
         super.setUp();
 
         TestDeployer.TroveManagerParams[] memory p = new TestDeployer.TroveManagerParams[](4);
-        p[0] = TestDeployer.TroveManagerParams(1.5 ether, 1.1 ether, 0.1 ether, 1.01 ether, 10_000_000e18, 0.05 ether, 0.1 ether);
-        p[1] = TestDeployer.TroveManagerParams(1.6 ether, 1.2 ether, 0.1 ether, 1.01 ether, 10_000_000e18, 0.05 ether, 0.1 ether);
-        p[2] = TestDeployer.TroveManagerParams(1.6 ether, 1.2 ether, 0.1 ether, 1.01 ether, 10_000_000e18, 0.05 ether, 0.1 ether);
-        p[3] = TestDeployer.TroveManagerParams(1.6 ether, 1.25 ether, 0.1 ether, 1.01 ether, 10_000_000e18, 0.05 ether, 0.1 ether);
+        p[0] = TestDeployer.TroveManagerParams(1.5 ether, 1.1 ether, 0.1 ether, 1.01 ether, 10_000_000e18, 0.05 ether, 0.1 ether, 0);
+        p[1] = TestDeployer.TroveManagerParams(1.6 ether, 1.2 ether, 0.1 ether, 1.01 ether, 10_000_000e18, 0.05 ether, 0.1 ether, 1);
+        p[2] = TestDeployer.TroveManagerParams(1.6 ether, 1.2 ether, 0.1 ether, 1.01 ether, 10_000_000e18, 0.05 ether, 0.1 ether, 2);
+        p[3] = TestDeployer.TroveManagerParams(1.6 ether, 1.25 ether, 0.1 ether, 1.01 ether, 10_000_000e18, 0.05 ether, 0.1 ether, 3);
         TestDeployer deployer = new TestDeployer();
         Contracts memory contracts;
         (contracts.branches, contracts.collateralRegistry, contracts.boldToken, contracts.hintHelpers,, contracts.weth,)

--- a/contracts/test/Invariants.t.sol
+++ b/contracts/test/Invariants.t.sol
@@ -72,16 +72,16 @@ contract InvariantsTest is Assertions, Logging, BaseInvariantTest, BaseMultiColl
         // TODO: randomize params? How to do it with Foundry invariant testing?
         TestDeployer.TroveManagerParams[] memory p = new TestDeployer.TroveManagerParams[](n);
         if (n > 0) {
-            p[0] = TestDeployer.TroveManagerParams(1.5 ether, 1.1 ether, 0.1 ether, 1.1 ether, 10_000_000e18, 0.05 ether, 0.1 ether);
+            p[0] = TestDeployer.TroveManagerParams(1.5 ether, 1.1 ether, 0.1 ether, 1.1 ether, 10_000_000e18, 0.05 ether, 0.1 ether, 0);
         }
         if (n > 1) {
-            p[1] = TestDeployer.TroveManagerParams(1.6 ether, 1.2 ether, 0.1 ether, 1.2 ether, 10_000_000e18, 0.05 ether, 0.2 ether);
+            p[1] = TestDeployer.TroveManagerParams(1.6 ether, 1.2 ether, 0.1 ether, 1.2 ether, 10_000_000e18, 0.05 ether, 0.2 ether, 1);
         }
         if (n > 2) {
-            p[2] = TestDeployer.TroveManagerParams(1.6 ether, 1.2 ether, 0.1 ether, 1.2 ether, 10_000_000e18, 0.05 ether, 0.2 ether);
+            p[2] = TestDeployer.TroveManagerParams(1.6 ether, 1.2 ether, 0.1 ether, 1.2 ether, 10_000_000e18, 0.05 ether, 0.2 ether, 2);
         }
         if (n > 3) {
-            p[3] = TestDeployer.TroveManagerParams(1.6 ether, 1.25 ether, 0.1 ether, 1.01 ether, 10_000_000e18, 0.05 ether, 0.1 ether);
+            p[3] = TestDeployer.TroveManagerParams(1.6 ether, 1.25 ether, 0.1 ether, 1.01 ether, 10_000_000e18, 0.05 ether, 0.1 ether, 3);
         }
 
         TestDeployer deployer = new TestDeployer();

--- a/contracts/test/OracleMainnet.t.sol
+++ b/contracts/test/OracleMainnet.t.sol
@@ -109,7 +109,7 @@ contract OraclesMainnet is TestAccounts {
 
         vars.numCollaterals = 3;
         TestDeployer.TroveManagerParams memory tmParams =
-            TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 10_000_000e18, 5e16, 10e16);
+            TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 10_000_000e18, 5e16, 10e16, 0);
         TestDeployer.TroveManagerParams[] memory troveManagerParamsArray =
             new TestDeployer.TroveManagerParams[](vars.numCollaterals);
         for (uint256 i = 0; i < troveManagerParamsArray.length; i++) {

--- a/contracts/test/TestContracts/BaseTest.sol
+++ b/contracts/test/TestContracts/BaseTest.sol
@@ -36,6 +36,9 @@ contract BaseTest is TestAccounts, Logging, TroveId {
     uint256 LIQUIDATION_PENALTY_SP;
     uint256 LIQUIDATION_PENALTY_REDISTRIBUTION;
 
+    // Addresses
+    address governor;
+
     // Core contracts
     IAddressesRegistry addressesRegistry;
     IActivePool activePool;

--- a/contracts/test/TestContracts/DevTestSetup.sol
+++ b/contracts/test/TestContracts/DevTestSetup.sol
@@ -69,6 +69,7 @@ contract DevTestSetup is BaseTest {
         gasCompZapper = zappers.gasCompZapper;
         leverageZapperCurve = zappers.leverageZapperCurve;
         leverageZapperUniV3 = zappers.leverageZapperUniV3;
+        governor = deployer.GOVERNOR();
 
         // Give some Coll to test accounts, and approve it to BorrowerOperations
         uint256 initialCollAmount = 10_000_000_000e18;

--- a/contracts/test/TestContracts/TroveManagerTester.t.sol
+++ b/contracts/test/TestContracts/TroveManagerTester.t.sol
@@ -16,7 +16,7 @@ contract TroveManagerTester is ITroveManagerTester, TroveManager {
     // Extra buffer of collateral ratio to join a batch or adjust a trove inside a batch (on top of MCR)
     uint256 public immutable BCR;
 
-    constructor(IAddressesRegistry _addressesRegistry) TroveManager(_addressesRegistry) {
+    constructor(IAddressesRegistry _addressesRegistry, uint256 _branchId) TroveManager(_addressesRegistry, _branchId) {
         BCR = _addressesRegistry.BCR();
     }
 
@@ -28,11 +28,11 @@ contract TroveManagerTester is ITroveManagerTester, TroveManager {
     }
 
     function get_CCR() external view returns (uint256) {
-        return CCR;
+        return CCR();
     }
 
     function get_MCR() external view returns (uint256) {
-        return MCR;
+        return MCR();
     }
 
     function get_BCR() external view returns (uint256) {
@@ -40,7 +40,7 @@ contract TroveManagerTester is ITroveManagerTester, TroveManager {
     }
 
     function get_SCR() external view returns (uint256) {
-        return SCR;
+        return SCR();
     }
 
     function get_LIQUIDATION_PENALTY_SP() external view returns (uint256) {
@@ -96,7 +96,7 @@ contract TroveManagerTester is ITroveManagerTester, TroveManager {
     }
 
     function checkBelowCriticalThreshold(uint256 _price) external view override returns (bool) {
-        return _checkBelowCriticalThreshold(_price, CCR);
+        return _checkBelowCriticalThreshold(_price, CCR());
     }
 
     function computeICR(uint256 _coll, uint256 _debt, uint256 _price) external pure returns (uint256) {

--- a/contracts/test/basicOps.t.sol
+++ b/contracts/test/basicOps.t.sol
@@ -213,7 +213,6 @@ contract BasicOps is DevTestSetup {
 
 
     function testAddCollateral() public {
-
         IERC20Metadata[] memory tokens = new IERC20Metadata[](1);
         tokens[0] = IERC20Metadata(address(0x0000000000000000000000000000000000000000));
         ITroveManager[] memory troveManagers = new ITroveManager[](1);
@@ -221,11 +220,30 @@ contract BasicOps is DevTestSetup {
 
         // Deploy a new collateral registry
         CollateralRegistry myCollateralRegistry = new CollateralRegistryTester(boldToken, tokens, troveManagers, address(0x123));
-        
+        uint256 branchId = myCollateralRegistry.branches();
+
         vm.startPrank(address(0x123));
         IERC20Metadata collToken = new ERC20Faucet("Test", "TEST", 100 ether, 1 days);
-        ITroveManager troveManager = new TroveManager(addressesRegistry);
-        myCollateralRegistry.addCollateral(collToken, troveManager, 0);
+        ITroveManager troveManager = new TroveManager(addressesRegistry, branchId);
+        myCollateralRegistry.addCollateral(collToken, troveManager);
         vm.stopPrank();
+    }
+
+    function testRemoveCollateral() public {
+        IERC20Metadata[] memory tokens = new IERC20Metadata[](2);
+        tokens[0] = new ERC20Faucet("Test", "TEST", 100 ether, 1 days);
+        tokens[1] = new ERC20Faucet("Test", "TEST", 100 ether, 1 days);
+        ITroveManager[] memory troveManagers = new ITroveManager[](2);
+        troveManagers[0] = new TroveManager(addressesRegistry, 0);
+        troveManagers[1] = new TroveManager(addressesRegistry, 1);
+
+        // Deploy a new collateral registry
+        CollateralRegistry myCollateralRegistry = new CollateralRegistryTester(boldToken, tokens, troveManagers, address(0x123));
+
+        vm.startPrank(address(0x123));
+        myCollateralRegistry.removeCollateral(1);
+        vm.stopPrank();
+
+        assertEq(myCollateralRegistry.removedBranchIds(0), 1);
     }
 }

--- a/contracts/test/liquidationsLST.t.sol
+++ b/contracts/test/liquidationsLST.t.sol
@@ -25,7 +25,7 @@ contract LiquidationsLSTTest is DevTestSetup {
         TestDeployer deployer = new TestDeployer();
         TestDeployer.LiquityContractsDev memory contracts;
         (contracts, collateralRegistry, boldToken,,,,) = deployer.deployAndConnectContracts(
-            TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000e18, 5e16, 10e16)
+            TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000e18, 5e16, 10e16, 0)
         );
         collToken = contracts.collToken;
         activePool = contracts.activePool;

--- a/contracts/test/multicollateral.t.sol
+++ b/contracts/test/multicollateral.t.sol
@@ -70,10 +70,10 @@ contract MulticollateralTest is DevTestSetup {
 
         TestDeployer.TroveManagerParams[] memory troveManagerParamsArray =
             new TestDeployer.TroveManagerParams[](NUM_COLLATERALS);
-        troveManagerParamsArray[0] = TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 10_000_000e18, 5e16, 10e16);
-        troveManagerParamsArray[1] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000e18, 5e16, 10e16);
-        troveManagerParamsArray[2] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000e18, 5e16, 10e16);
-        troveManagerParamsArray[3] = TestDeployer.TroveManagerParams(160e16, 125e16, 10e16, 125e16, 10_000_000e18, 5e16, 10e16);
+        troveManagerParamsArray[0] = TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 10_000_000e18, 5e16, 10e16, 0);
+        troveManagerParamsArray[1] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000e18, 5e16, 10e16, 1);
+        troveManagerParamsArray[2] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000e18, 5e16, 10e16, 2);
+        troveManagerParamsArray[3] = TestDeployer.TroveManagerParams(160e16, 125e16, 10e16, 125e16, 10_000_000e18, 5e16, 10e16, 3);
 
         TestDeployer deployer = new TestDeployer();
         TestDeployer.LiquityContractsDev[] memory _contractsArray;
@@ -779,7 +779,8 @@ contract CsBold013 is TestAccounts {
             BCR: BCR_ALL,
             LIQUIDATION_PENALTY_SP: LIQUIDATION_PENALTY_SP_WETH,
             LIQUIDATION_PENALTY_REDISTRIBUTION: LIQUIDATION_PENALTY_REDISTRIBUTION_WETH,
-            debtLimit: MAX_INT
+            debtLimit: MAX_INT,
+            branchId: 0
         });
 
         // wstETH
@@ -790,7 +791,8 @@ contract CsBold013 is TestAccounts {
             BCR: BCR_ALL,
             LIQUIDATION_PENALTY_SP: LIQUIDATION_PENALTY_SP_SETH,
             LIQUIDATION_PENALTY_REDISTRIBUTION: LIQUIDATION_PENALTY_REDISTRIBUTION_SETH,
-            debtLimit: MAX_INT/2
+            debtLimit: MAX_INT/2,
+            branchId: 1
         });
 
         // rETH (same as wstETH)

--- a/contracts/test/redemptions.t.sol
+++ b/contracts/test/redemptions.t.sol
@@ -1083,4 +1083,24 @@ contract Redemptions is DevTestSetup {
 
     // TODO: tests borrower for combined adjustments - debt changes and coll add/withdrawals.
     // Borrower should only be able to close OR leave Trove at >= min net debt.
+
+
+    function testRedemptionAfterCollateralRemoved() public {
+        (,, ABCDEF memory troveIDs) = _setupForRedemptionAscendingInterest();
+
+        // Remove collateral branch
+        vm.prank(governor);
+        collateralRegistry.removeCollateral(0);
+
+        uint256 debt_A = troveManager.getTroveEntireDebt(troveIDs.A);
+        uint256 debt_B = troveManager.getTroveEntireDebt(troveIDs.B);
+
+        // E redeems enough to fully redeem A and B
+        uint256 redeemAmount_1 = debt_A + debt_B;
+        redeem(E, redeemAmount_1);
+
+        // Check A and B's Trove debt equals zero
+        assertEq(troveManager.getTroveEntireDebt(troveIDs.A), 0);
+        assertEq(troveManager.getTroveEntireDebt(troveIDs.B), 0);
+    }
 }

--- a/contracts/test/shutdown.t.sol
+++ b/contracts/test/shutdown.t.sol
@@ -27,10 +27,10 @@ contract ShutdownTest is DevTestSetup {
 
         TestDeployer.TroveManagerParams[] memory troveManagerParamsArray =
             new TestDeployer.TroveManagerParams[](NUM_COLLATERALS);
-        troveManagerParamsArray[0] = TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 10_000_000e18, 5e16, 10e16);
-        troveManagerParamsArray[1] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000e18, 5e16, 10e16);
-        troveManagerParamsArray[2] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000e18, 5e16, 10e16);
-        troveManagerParamsArray[3] = TestDeployer.TroveManagerParams(160e16, 125e16, 10e16, 125e16, 10_000_000e18, 5e16, 10e16);
+        troveManagerParamsArray[0] = TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 10_000_000e18, 5e16, 10e16, 0);
+        troveManagerParamsArray[1] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000e18, 5e16, 10e16, 1);
+        troveManagerParamsArray[2] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000e18, 5e16, 10e16, 2);
+        troveManagerParamsArray[3] = TestDeployer.TroveManagerParams(160e16, 125e16, 10e16, 125e16, 10_000_000e18, 5e16, 10e16, 3);
 
         TestDeployer deployer = new TestDeployer();
         TestDeployer.LiquityContractsDev[] memory _contractsArray;

--- a/contracts/test/troveNFT.t.sol
+++ b/contracts/test/troveNFT.t.sol
@@ -69,9 +69,9 @@ contract troveNFTTest is DevTestSetup {
 
         TestDeployer.TroveManagerParams[] memory troveManagerParamsArray =
             new TestDeployer.TroveManagerParams[](NUM_COLLATERALS);
-        troveManagerParamsArray[0] = TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 10_000_000e18, 5e16, 10e16);
-        troveManagerParamsArray[1] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000e18, 5e16, 10e16);
-        troveManagerParamsArray[2] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000e18, 5e16, 10e16);
+        troveManagerParamsArray[0] = TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 10_000_000e18, 5e16, 10e16, 0);
+        troveManagerParamsArray[1] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000e18, 5e16, 10e16, 1);
+        troveManagerParamsArray[2] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000e18, 5e16, 10e16, 2);
 
         TestDeployer deployer = new TestDeployer();
         TestDeployer.LiquityContractsDev[] memory _contractsArray;

--- a/contracts/test/zapperGasComp.t.sol
+++ b/contracts/test/zapperGasComp.t.sol
@@ -27,8 +27,8 @@ contract ZapperGasCompTest is DevTestSetup {
         WETH = new WETH9();
 
         TestDeployer.TroveManagerParams[] memory troveManagerParams = new TestDeployer.TroveManagerParams[](2);
-        troveManagerParams[0] = TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 10_000_000e18, 5e16, 10e16);
-        troveManagerParams[1] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000e18, 5e16, 10e16);
+        troveManagerParams[0] = TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 10_000_000e18, 5e16, 10e16, 0);
+        troveManagerParams[1] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000e18, 5e16, 10e16, 1);
 
         TestDeployer deployer = new TestDeployer();
         TestDeployer.LiquityContractsDev[] memory contractsArray;

--- a/contracts/test/zapperLeverage.t.sol
+++ b/contracts/test/zapperLeverage.t.sol
@@ -128,9 +128,9 @@ contract ZapperLeverageMainnet is DevTestSetup {
 
         TestDeployer.TroveManagerParams[] memory troveManagerParamsArray =
             new TestDeployer.TroveManagerParams[](NUM_COLLATERALS);
-        troveManagerParamsArray[0] = TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 10_000_000e18, 5e16, 10e16);
+        troveManagerParamsArray[0] = TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 10_000_000e18, 5e16, 10e16, 0);
         for (uint256 c = 0; c < NUM_COLLATERALS; c++) {
-            troveManagerParamsArray[c] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000e18, 5e16, 10e16);
+            troveManagerParamsArray[c] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000e18, 5e16, 10e16, c);
         }
 
         TestDeployer deployer = new TestDeployer();

--- a/contracts/test/zapperWETH.t.sol
+++ b/contracts/test/zapperWETH.t.sol
@@ -27,7 +27,7 @@ contract ZapperWETHTest is DevTestSetup {
         WETH = new WETH9();
 
         TestDeployer.TroveManagerParams[] memory troveManagerParams = new TestDeployer.TroveManagerParams[](1);
-        troveManagerParams[0] = TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 10_000_000e18, 5e16, 10e16);
+        troveManagerParams[0] = TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 10_000_000e18, 5e16, 10e16, 0);
 
         TestDeployer deployer = new TestDeployer();
         TestDeployer.LiquityContractsDev[] memory contractsArray;


### PR DESCRIPTION
closes #11 

The function can ONLY be called by `TroveManager` address of `branchId` being deleted from `removedBranchIds` array. `TroveManager` checks if its branch is active in `_closeTrove` function. If returns `false`, then 2 things happen:
1. The requirement `_requireMoreThanOneTroveInSystem(TroveIdsArrayLength);` is skipped even if conditions `shutdownTime == 0 || closedStatus == Status.closedByLiquidation` are met.
2. `CollateralRegistry.deleteFromRemovedCollaterals(uint256 _branch)` is called if the condition `TroveIdsArrayLength == 1` is met (in other words, this is the last trove in the branch being closed).

Everything else remains normal.