### PR TITLE
Add build and deploy scripts to package.json for subgraph

### DIFF
--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -4,10 +4,13 @@
   "license": "MIT",
   "version": "1.0.0",
   "scripts": {
-    "codegen": "pnpm graph codegen"
+    "codegen": "pnpm graph codegen",
+    "build": "pnpm graph build",
+    "deploy": "goldsky subgraph deploy --path build"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "^0.97.0"
+    "@graphprotocol/graph-cli": "^0.97.0",
+    "@goldskycom/cli": "^13.0.0"
   },
   "dependencies": {
     "@graphprotocol/graph-ts": "^0.38.0",


### PR DESCRIPTION
`codegen` and `build` will remain the same using The Graph's CLI. Goldsky can deploy the subgraph from the `build` folder generated from `graph build`. These scripts added in `package.json` just simplify the commands more.