### PR TITLE
Fix unit tests

### DIFF
--- a/contracts/test/AnchoredInvariantsTest.t.sol
+++ b/contracts/test/AnchoredInvariantsTest.t.sol
@@ -10,6 +10,8 @@ import {AdjustedTroveProperties, InvariantsTestHandler} from "./TestContracts/In
 import {Logging} from "./Utils/Logging.sol";
 import {TroveId} from "./Utils/TroveId.sol";
 
+uint256 constant MAX_INT = type(uint256).max;
+
 contract AnchoredInvariantsTest is Logging, BaseInvariantTest, BaseMultiCollateralTest, TroveId {
     using Strings for uint256;
     using StringFormatting for uint256;
@@ -20,14 +22,16 @@ contract AnchoredInvariantsTest is Logging, BaseInvariantTest, BaseMultiCollater
         super.setUp();
 
         TestDeployer.TroveManagerParams[] memory p = new TestDeployer.TroveManagerParams[](4);
-        p[0] = TestDeployer.TroveManagerParams(1.5 ether, 1.1 ether, 0.1 ether, 1.01 ether, 10_000_000e18, 0.05 ether, 0.1 ether, 0);
-        p[1] = TestDeployer.TroveManagerParams(1.6 ether, 1.2 ether, 0.1 ether, 1.01 ether, 10_000_000e18, 0.05 ether, 0.1 ether, 1);
-        p[2] = TestDeployer.TroveManagerParams(1.6 ether, 1.2 ether, 0.1 ether, 1.01 ether, 10_000_000e18, 0.05 ether, 0.1 ether, 2);
-        p[3] = TestDeployer.TroveManagerParams(1.6 ether, 1.25 ether, 0.1 ether, 1.01 ether, 10_000_000e18, 0.05 ether, 0.1 ether, 3);
+        p[0] = TestDeployer.TroveManagerParams(1.5 ether, 1.1 ether, 0.1 ether, 1.01 ether, MAX_INT, 0.05 ether, 0.1 ether, 0);
+        p[1] = TestDeployer.TroveManagerParams(1.6 ether, 1.2 ether, 0.1 ether, 1.01 ether, MAX_INT/2, 0.05 ether, 0.1 ether, 1);
+        p[2] = TestDeployer.TroveManagerParams(1.6 ether, 1.2 ether, 0.1 ether, 1.01 ether, MAX_INT/2, 0.05 ether, 0.1 ether, 2);
+        p[3] = TestDeployer.TroveManagerParams(1.6 ether, 1.25 ether, 0.1 ether, 1.01 ether, MAX_INT/2, 0.05 ether, 0.1 ether, 3);
+        console.log("Deploying contracts");
         TestDeployer deployer = new TestDeployer();
         Contracts memory contracts;
         (contracts.branches, contracts.collateralRegistry, contracts.boldToken, contracts.hintHelpers,, contracts.weth,)
         = deployer.deployAndConnectContractsMultiColl(p);
+        console.log("Deployed contracts");
         setupContracts(contracts);
 
         handler = new InvariantsTestHandler({contracts: contracts, assumeNoExpectedFailures: true});

--- a/contracts/test/AnchoredInvariantsTest.t.sol
+++ b/contracts/test/AnchoredInvariantsTest.t.sol
@@ -26,12 +26,10 @@ contract AnchoredInvariantsTest is Logging, BaseInvariantTest, BaseMultiCollater
         p[1] = TestDeployer.TroveManagerParams(1.6 ether, 1.2 ether, 0.1 ether, 1.01 ether, MAX_INT/2, 0.05 ether, 0.1 ether, 1);
         p[2] = TestDeployer.TroveManagerParams(1.6 ether, 1.2 ether, 0.1 ether, 1.01 ether, MAX_INT/2, 0.05 ether, 0.1 ether, 2);
         p[3] = TestDeployer.TroveManagerParams(1.6 ether, 1.25 ether, 0.1 ether, 1.01 ether, MAX_INT/2, 0.05 ether, 0.1 ether, 3);
-        console.log("Deploying contracts");
         TestDeployer deployer = new TestDeployer();
         Contracts memory contracts;
         (contracts.branches, contracts.collateralRegistry, contracts.boldToken, contracts.hintHelpers,, contracts.weth,)
         = deployer.deployAndConnectContractsMultiColl(p);
-        console.log("Deployed contracts");
         setupContracts(contracts);
 
         handler = new InvariantsTestHandler({contracts: contracts, assumeNoExpectedFailures: true});

--- a/contracts/test/Invariants.t.sol
+++ b/contracts/test/Invariants.t.sol
@@ -72,16 +72,16 @@ contract InvariantsTest is Assertions, Logging, BaseInvariantTest, BaseMultiColl
         // TODO: randomize params? How to do it with Foundry invariant testing?
         TestDeployer.TroveManagerParams[] memory p = new TestDeployer.TroveManagerParams[](n);
         if (n > 0) {
-            p[0] = TestDeployer.TroveManagerParams(1.5 ether, 1.1 ether, 0.1 ether, 1.1 ether, 10_000_000e18, 0.05 ether, 0.1 ether, 0);
+            p[0] = TestDeployer.TroveManagerParams(1.5 ether, 1.1 ether, 0.1 ether, 1.1 ether, 10_000_000_000e18, 0.05 ether, 0.1 ether, 0);
         }
         if (n > 1) {
-            p[1] = TestDeployer.TroveManagerParams(1.6 ether, 1.2 ether, 0.1 ether, 1.2 ether, 10_000_000e18, 0.05 ether, 0.2 ether, 1);
+            p[1] = TestDeployer.TroveManagerParams(1.6 ether, 1.2 ether, 0.1 ether, 1.2 ether, 10_000_000_000e18, 0.05 ether, 0.2 ether, 1);
         }
         if (n > 2) {
-            p[2] = TestDeployer.TroveManagerParams(1.6 ether, 1.2 ether, 0.1 ether, 1.2 ether, 10_000_000e18, 0.05 ether, 0.2 ether, 2);
+            p[2] = TestDeployer.TroveManagerParams(1.6 ether, 1.2 ether, 0.1 ether, 1.2 ether, 10_000_000_000e18, 0.05 ether, 0.2 ether, 2);
         }
         if (n > 3) {
-            p[3] = TestDeployer.TroveManagerParams(1.6 ether, 1.25 ether, 0.1 ether, 1.01 ether, 10_000_000e18, 0.05 ether, 0.1 ether, 3);
+            p[3] = TestDeployer.TroveManagerParams(1.6 ether, 1.25 ether, 0.1 ether, 1.01 ether, 10_000_000_000e18, 0.05 ether, 0.1 ether, 3);
         }
 
         TestDeployer deployer = new TestDeployer();

--- a/contracts/test/TestContracts/Deployment.t.sol
+++ b/contracts/test/TestContracts/Deployment.t.sol
@@ -344,6 +344,7 @@ contract TestDeployer is MetadataDeployment {
         multiTroveGetter = new MultiTroveGetter(collateralRegistry);
 
         (contractsArray[0], zappersArray[0]) = _deployAndConnectCollateralContractsDev(
+            0,
             _WETH,
             boldToken,
             collateralRegistry,
@@ -357,6 +358,7 @@ contract TestDeployer is MetadataDeployment {
         // Deploy the remaining branches with LST collateral
         for (vars.i = 1; vars.i < vars.numCollaterals; vars.i++) {
             (contractsArray[vars.i], zappersArray[vars.i]) = _deployAndConnectCollateralContractsDev(
+                vars.i,
                 vars.collaterals[vars.i],
                 boldToken,
                 collateralRegistry,
@@ -393,6 +395,7 @@ contract TestDeployer is MetadataDeployment {
     }
 
     function _deployAndConnectCollateralContractsDev(
+        uint256 _branchId,
         IERC20Metadata _collToken,
         IBoldToken _boldToken,
         ICollateralRegistry _collateralRegistry,
@@ -470,7 +473,7 @@ contract TestDeployer is MetadataDeployment {
         contracts.addressesRegistry.setAddresses(addressVars);
 
         contracts.borrowerOperations = new BorrowerOperationsTester{salt: SALT}(contracts.addressesRegistry);
-        contracts.troveManager = new TroveManagerTester{salt: SALT}(contracts.addressesRegistry, 0);
+        contracts.troveManager = new TroveManagerTester{salt: SALT}(contracts.addressesRegistry, _branchId);
         contracts.troveNFT = new TroveNFT{salt: SALT}(contracts.addressesRegistry);
         contracts.stabilityPool = new StabilityPool{salt: SALT}(contracts.addressesRegistry);
         contracts.activePool = new ActivePool{salt: SALT}(contracts.addressesRegistry);

--- a/contracts/test/TestContracts/Deployment.t.sol
+++ b/contracts/test/TestContracts/Deployment.t.sol
@@ -48,6 +48,7 @@ import "src/PriceFeeds/RETHPriceFeed.sol";
 import "forge-std/console2.sol";
 import "forge-std/Test.sol";
 
+uint256 constant MAX_INT = type(uint256).max;
 uint256 constant _24_HOURS = 86400;
 uint256 constant _48_HOURS = 172800;
 
@@ -233,7 +234,7 @@ contract TestDeployer is MetadataDeployment {
             Zappers memory zappers
         )
     {
-        return deployAndConnectContracts(TroveManagerParams(150e16, 110e16, 10e16, 110e16, 10_000_000e18, 5e16, 10e16, 0));
+        return deployAndConnectContracts(TroveManagerParams(150e16, 110e16, 10e16, 110e16, MAX_INT, 5e16, 10e16, 0));
     }
 
     function deployAndConnectContracts(TroveManagerParams memory troveManagerParams)

--- a/contracts/test/multicollateral.t.sol
+++ b/contracts/test/multicollateral.t.sol
@@ -121,8 +121,12 @@ contract MulticollateralTest is DevTestSetup {
             assertNotEq(address(collateralRegistry.getTroveManager(c)), ZERO_ADDRESS, "Missing TroveManager");
         }
         for (uint256 c = NUM_COLLATERALS; c < 10; c++) {
-            assertEq(address(collateralRegistry.getToken(c)), ZERO_ADDRESS, "Extra collateral token");
-            assertEq(address(collateralRegistry.getTroveManager(c)), ZERO_ADDRESS, "Extra TroveManager");
+            vm.expectRevert("Invalid index");
+            collateralRegistry.getToken(c);
+            vm.expectRevert("Invalid index");
+            collateralRegistry.getTroveManager(c);
+            // assertEq(address(collateralRegistry.getToken(c)), ZERO_ADDRESS, "Extra collateral token");
+            // assertEq(address(collateralRegistry.getTroveManager(c)), ZERO_ADDRESS, "Extra TroveManager");
         }
         // reverts for invalid index
         vm.expectRevert("Invalid index");
@@ -796,7 +800,16 @@ contract CsBold013 is TestAccounts {
         });
 
         // rETH (same as wstETH)
-        params[2] = params[1];
+        params[2] = TestDeployer.TroveManagerParams({
+            CCR: CCR_SETH,
+            MCR: MCR_SETH,
+            SCR: SCR_SETH,
+            BCR: BCR_ALL,
+            LIQUIDATION_PENALTY_SP: LIQUIDATION_PENALTY_SP_SETH,
+            LIQUIDATION_PENALTY_REDISTRIBUTION: LIQUIDATION_PENALTY_REDISTRIBUTION_SETH,
+            debtLimit: MAX_INT/2,
+            branchId: 2
+        });
 
         TestDeployer deployer = new TestDeployer();
         TestDeployer.LiquityContractsDev[] memory _branches;

--- a/contracts/test/multicollateral.t.sol
+++ b/contracts/test/multicollateral.t.sol
@@ -70,10 +70,10 @@ contract MulticollateralTest is DevTestSetup {
 
         TestDeployer.TroveManagerParams[] memory troveManagerParamsArray =
             new TestDeployer.TroveManagerParams[](NUM_COLLATERALS);
-        troveManagerParamsArray[0] = TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 10_000_000e18, 5e16, 10e16, 0);
-        troveManagerParamsArray[1] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000e18, 5e16, 10e16, 1);
-        troveManagerParamsArray[2] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000e18, 5e16, 10e16, 2);
-        troveManagerParamsArray[3] = TestDeployer.TroveManagerParams(160e16, 125e16, 10e16, 125e16, 10_000_000e18, 5e16, 10e16, 3);
+        troveManagerParamsArray[0] = TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 10_000_000_000e18, 5e16, 10e16, 0);
+        troveManagerParamsArray[1] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000_000e18, 5e16, 10e16, 1);
+        troveManagerParamsArray[2] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000_000e18, 5e16, 10e16, 2);
+        troveManagerParamsArray[3] = TestDeployer.TroveManagerParams(160e16, 125e16, 10e16, 125e16, 10_000_000_000e18, 5e16, 10e16, 3);
 
         TestDeployer deployer = new TestDeployer();
         TestDeployer.LiquityContractsDev[] memory _contractsArray;

--- a/contracts/test/shutdown.t.sol
+++ b/contracts/test/shutdown.t.sol
@@ -27,10 +27,10 @@ contract ShutdownTest is DevTestSetup {
 
         TestDeployer.TroveManagerParams[] memory troveManagerParamsArray =
             new TestDeployer.TroveManagerParams[](NUM_COLLATERALS);
-        troveManagerParamsArray[0] = TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 10_000_000e18, 5e16, 10e16, 0);
-        troveManagerParamsArray[1] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000e18, 5e16, 10e16, 1);
-        troveManagerParamsArray[2] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000e18, 5e16, 10e16, 2);
-        troveManagerParamsArray[3] = TestDeployer.TroveManagerParams(160e16, 125e16, 10e16, 125e16, 10_000_000e18, 5e16, 10e16, 3);
+        troveManagerParamsArray[0] = TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 10_000_000_000e18, 5e16, 10e16, 0);
+        troveManagerParamsArray[1] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000_000e18, 5e16, 10e16, 1);
+        troveManagerParamsArray[2] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000_000e18, 5e16, 10e16, 2);
+        troveManagerParamsArray[3] = TestDeployer.TroveManagerParams(160e16, 125e16, 10e16, 125e16, 10_000_000_000e18, 5e16, 10e16, 3);
 
         TestDeployer deployer = new TestDeployer();
         TestDeployer.LiquityContractsDev[] memory _contractsArray;

--- a/contracts/test/troveNFT.t.sol
+++ b/contracts/test/troveNFT.t.sol
@@ -73,12 +73,10 @@ contract troveNFTTest is DevTestSetup {
         troveManagerParamsArray[1] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000_000e18, 5e16, 10e16, 1);
         troveManagerParamsArray[2] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000_000e18, 5e16, 10e16, 2);
 
-        console.log("Deploying contracts");
         TestDeployer deployer = new TestDeployer();
         TestDeployer.LiquityContractsDev[] memory _contractsArray;
         (_contractsArray, collateralRegistry, boldToken,,, WETH,) =
             deployer.deployAndConnectContractsMultiColl(troveManagerParamsArray);
-        console.log("Deployed contracts");
         // Unimplemented feature (...):Copying of type struct LiquityContracts memory[] memory to storage not yet supported.
         for (uint256 c = 0; c < NUM_COLLATERALS; c++) {
             contractsArray.push(_contractsArray[c]);

--- a/contracts/test/troveNFT.t.sol
+++ b/contracts/test/troveNFT.t.sol
@@ -69,14 +69,16 @@ contract troveNFTTest is DevTestSetup {
 
         TestDeployer.TroveManagerParams[] memory troveManagerParamsArray =
             new TestDeployer.TroveManagerParams[](NUM_COLLATERALS);
-        troveManagerParamsArray[0] = TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 10_000_000e18, 5e16, 10e16, 0);
-        troveManagerParamsArray[1] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000e18, 5e16, 10e16, 1);
-        troveManagerParamsArray[2] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000e18, 5e16, 10e16, 2);
+        troveManagerParamsArray[0] = TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 10_000_000_000e18, 5e16, 10e16, 0);
+        troveManagerParamsArray[1] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000_000e18, 5e16, 10e16, 1);
+        troveManagerParamsArray[2] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 10_000_000_000e18, 5e16, 10e16, 2);
 
+        console.log("Deploying contracts");
         TestDeployer deployer = new TestDeployer();
         TestDeployer.LiquityContractsDev[] memory _contractsArray;
         (_contractsArray, collateralRegistry, boldToken,,, WETH,) =
             deployer.deployAndConnectContractsMultiColl(troveManagerParamsArray);
+        console.log("Deployed contracts");
         // Unimplemented feature (...):Copying of type struct LiquityContracts memory[] memory to storage not yet supported.
         for (uint256 c = 0; c < NUM_COLLATERALS; c++) {
             contractsArray.push(_contractsArray[c]);


### PR DESCRIPTION
Fixed test setup. There are 2 errors that were causing some of the unit tests to break:
1. [✅ Fixed] The debt limit. It was set too small in the test setup. Resolved by increasing it to max uint256 value or half of it.
2. [✅ Fixed] An assertion error in deployment setup for tests that use `deployAndConnectContractsMultiColl`. Resolved by updating `_deployAndConnectCollateralContractsDev` internal function with new param `uint256 _branchId` for correct `TroveManager` deployed address.

All tests pass both in EVM versions Cancun and Prague.