### PR TITLE
Fix TroveNFT constructor (set governor address) + DeployLiquity2Script

### DIFF
--- a/contracts/src/TroveNFT.sol
+++ b/contracts/src/TroveNFT.sol
@@ -27,16 +27,18 @@ contract TroveNFT is ERC721, ITroveNFT {
 
 
 
-    constructor(IAddressesRegistry _addressesRegistry, address governor)
+    constructor(IAddressesRegistry _addressesRegistry, address _governor)
         ERC721(
             string.concat("Liquity V2 - ", _addressesRegistry.collToken().name()),
             string.concat("LV2_", _addressesRegistry.collToken().symbol())
         )
     {
+        require(_governor != address(0), "TroveNFT: Governor cannot be the zero address");
         troveManager = _addressesRegistry.troveManager();
         collToken = _addressesRegistry.collToken();
         metadataNFT = _addressesRegistry.metadataNFT();
         boldToken = _addressesRegistry.boldToken();
+        governor = _governor;
     }
 
     function tokenURI(uint256 _tokenId) public view override(ERC721, IERC721Metadata) returns (string memory) {

--- a/contracts/src/Zappers/GasCompZapper.sol
+++ b/contracts/src/Zappers/GasCompZapper.sol
@@ -23,7 +23,7 @@ contract GasCompZapper is BaseZapper {
         // Approve coll to BorrowerOperations
         collToken.approve(address(borrowerOperations), type(uint256).max);
         // Approve Coll to exchange module (for closeTroveFromCollateral)
-        collToken.approve(address(_exchange), type(uint256).max);
+        // collToken.approve(address(_exchange), type(uint256).max); // Not using exchange at the moment
     }
 
     function openTroveWithRawETH(OpenTroveParams calldata _params) external payable returns (uint256) {

--- a/contracts/src/Zappers/WETHZapper.sol
+++ b/contracts/src/Zappers/WETHZapper.sol
@@ -14,7 +14,7 @@ contract WETHZapper is BaseZapper {
         // Approve coll to BorrowerOperations
         WETH.approve(address(borrowerOperations), type(uint256).max);
         // Approve Coll to exchange module (for closeTroveFromCollateral)
-        WETH.approve(address(_exchange), type(uint256).max);
+        // WETH.approve(address(_exchange), type(uint256).max); // Not using exchange at the moment
     }
 
     function openTroveWithRawETH(OpenTroveParams calldata _params) external payable returns (uint256) {

--- a/contracts/test/TestContracts/Deployment.t.sol
+++ b/contracts/test/TestContracts/Deployment.t.sol
@@ -211,6 +211,10 @@ contract TestDeployer is MetadataDeployment {
         return abi.encodePacked(_creationCode, abi.encode(_addressesRegistry));
     }
 
+    function getBytecode(bytes memory _creationCode, address _addressesRegistry, address _governor) public pure returns (bytes memory) {
+        return abi.encodePacked(_creationCode, abi.encode(_addressesRegistry, _governor));
+    }
+
     function getBytecode(bytes memory _creationCode, address _addressesRegistry, uint256 _branchId) public pure returns (bytes memory) {
         return abi.encodePacked(_creationCode, abi.encode(_addressesRegistry, _branchId));
     }
@@ -428,7 +432,7 @@ contract TestDeployer is MetadataDeployment {
         );
         addresses.troveManager = _troveManagerAddress;
         addresses.troveNFT = getAddress(
-            address(this), getBytecode(type(TroveNFT).creationCode, address(contracts.addressesRegistry)), SALT
+            address(this), getBytecode(type(TroveNFT).creationCode, address(contracts.addressesRegistry), GOVERNOR), SALT
         );
         addresses.stabilityPool = getAddress(
             address(this), getBytecode(type(StabilityPool).creationCode, address(contracts.addressesRegistry)), SALT
@@ -474,7 +478,7 @@ contract TestDeployer is MetadataDeployment {
 
         contracts.borrowerOperations = new BorrowerOperationsTester{salt: SALT}(contracts.addressesRegistry);
         contracts.troveManager = new TroveManagerTester{salt: SALT}(contracts.addressesRegistry, _branchId);
-        contracts.troveNFT = new TroveNFT{salt: SALT}(contracts.addressesRegistry);
+        contracts.troveNFT = new TroveNFT{salt: SALT}(contracts.addressesRegistry, GOVERNOR);
         contracts.stabilityPool = new StabilityPool{salt: SALT}(contracts.addressesRegistry);
         contracts.activePool = new ActivePool{salt: SALT}(contracts.addressesRegistry);
         contracts.pools.defaultPool = new DefaultPool{salt: SALT}(contracts.addressesRegistry);
@@ -644,7 +648,7 @@ contract TestDeployer is MetadataDeployment {
         );
         addresses.troveManager = _params.troveManagerAddress;
         addresses.troveNFT = getAddress(
-            address(this), getBytecode(type(TroveNFT).creationCode, address(contracts.addressesRegistry)), SALT
+            address(this), getBytecode(type(TroveNFT).creationCode, address(contracts.addressesRegistry), GOVERNOR), SALT
         );
         addresses.stabilityPool = getAddress(
             address(this), getBytecode(type(StabilityPool).creationCode, address(contracts.addressesRegistry)), SALT
@@ -693,7 +697,7 @@ contract TestDeployer is MetadataDeployment {
 
         contracts.borrowerOperations = new BorrowerOperationsTester{salt: SALT}(contracts.addressesRegistry);
         contracts.troveManager = new TroveManager{salt: SALT}(contracts.addressesRegistry, 0);
-        contracts.troveNFT = new TroveNFT{salt: SALT}(contracts.addressesRegistry);
+        contracts.troveNFT = new TroveNFT{salt: SALT}(contracts.addressesRegistry, GOVERNOR);
         contracts.stabilityPool = new StabilityPool{salt: SALT}(contracts.addressesRegistry);
         contracts.activePool = new ActivePool{salt: SALT}(contracts.addressesRegistry);
         contracts.defaultPool = new DefaultPool{salt: SALT}(contracts.addressesRegistry);


### PR DESCRIPTION
Made the following changes:
- Set governor address in TroveNFT constructor
- Comment out token approval of exchange module in zappers (because we are not using exchanges)
- Tweaks and fixes to DeployLiquity2Script. Now simulates full deployment.

NOTE: The BorrowerOperations is over the contract size limit by a tiny margin.