### PR TITLE
Create WrappedToken contract with 18 decimals for FBTC and SAGA

### DIFF
--- a/contracts/script/DeployLiquity2.s.sol
+++ b/contracts/script/DeployLiquity2.s.sol
@@ -49,6 +49,7 @@ import "src/Zappers/Modules/Exchanges/UniswapV3/IUniswapV3Factory.sol";
 import "src/Zappers/Modules/Exchanges/UniswapV3/INonfungiblePositionManager.sol";
 import "src/Zappers/Modules/Exchanges/UniswapV3/UniPriceConverter.sol";
 import "src/Zappers/Modules/Exchanges/HybridCurveUniV3Exchange.sol";
+import "src/ERC20Wrappers/WrappedToken.sol";
 import {WETHTester} from "test/TestContracts/WETHTester.sol";
 import "forge-std/console2.sol";
 import {IRateProvider, IWeightedPool, IWeightedPoolFactory} from "./Interfaces/Balancer/IWeightedPool.sol";
@@ -486,10 +487,6 @@ contract DeployLiquity2Script is DeployGovernance, UniPriceConverter, StdCheats,
         return abi.encodePacked(_creationCode, abi.encode(_addressesRegistry));
     }
 
-    function getBytecode(bytes memory _creationCode, address _addressesRegistry, address _governor) public pure returns (bytes memory) {
-        return abi.encodePacked(_creationCode, abi.encode(_addressesRegistry, _governor));
-    }
-
     function getBytecode(bytes memory _creationCode, address _addressesRegistry, uint256 _branchId) public pure returns (bytes memory) {
         return abi.encodePacked(_creationCode, abi.encode(_addressesRegistry, _branchId));
     }
@@ -536,10 +533,12 @@ contract DeployLiquity2Script is DeployGovernance, UniPriceConverter, StdCheats,
             vars.collaterals[2] = IERC20Metadata(TBTC_ADDRESS);
 
             // FBTC
-            vars.collaterals[3] = IERC20Metadata(FBTC_ADDRESS);
+            // vars.collaterals[3] = IERC20Metadata(FBTC_ADDRESS);
+            vars.collaterals[3] = new WrappedToken(IERC20Metadata(FBTC_ADDRESS));
 
             // SAGA
-            vars.collaterals[4] = IERC20Metadata(SAGA_ADDRESS);
+            // vars.collaterals[4] = IERC20Metadata(SAGA_ADDRESS);
+            vars.collaterals[4] = new WrappedToken(IERC20Metadata(SAGA_ADDRESS));
         } else {
             // Sepolia
             // Use WETH as collateral for the first branch

--- a/contracts/src/ERC20Wrappers/WrappedToken.sol
+++ b/contracts/src/ERC20Wrappers/WrappedToken.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity 0.8.24;
+
+import "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+import "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import "openzeppelin-contracts/contracts/token/ERC20/extensions/ERC20Wrapper.sol";
+import "openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+
+contract WrappedToken is ERC20Wrapper {
+    using SafeERC20 for IERC20;
+
+    uint8 internal immutable _decimalDiff;
+
+    constructor(IERC20Metadata underlyingToken) 
+    ERC20Wrapper(underlyingToken) 
+    ERC20(string.concat("Wrapped ", underlyingToken.name()), string.concat("w", underlyingToken.symbol()))
+    {
+        _decimalDiff = decimals() - underlyingToken.decimals();
+    }
+
+    /**
+     * @dev See {ERC20-decimals}.
+     */
+    function decimals() public view virtual override returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev Allow a user to deposit underlying tokens and mint the corresponding number of wrapped tokens.
+     */
+    function depositFor(address account, uint256 amount) public virtual override returns (bool) {
+        address sender = _msgSender();
+        require(sender != address(this), "ERC20Wrapper: wrapper can't deposit");
+        underlying().safeTransferFrom(sender, address(this), amount);
+        _mint(account, amount * 10**_decimalDiff);
+        return true;
+    }
+
+    /**
+     * @dev Allow a user to burn a number of wrapped tokens and withdraw the corresponding number of underlying tokens.
+     */
+    function withdrawTo(address account, uint256 amount) public virtual override returns (bool) {
+        _burn(_msgSender(), amount);
+        underlying().safeTransfer(account, amount / 10**_decimalDiff);
+        return true;
+    }
+
+    /**
+     * @dev Mint wrapped token to cover any underlyingTokens that would have been transferred by mistake. Internal
+     * function that can be exposed with access control if desired.
+     */
+    function _recover(address account) internal virtual override returns (uint256) {
+        uint256 value = underlying().balanceOf(address(this)) - totalSupply();
+        _mint(account, value * 10**_decimalDiff);
+        return value;
+    }
+}

--- a/contracts/test/TestContracts/Deployment.t.sol
+++ b/contracts/test/TestContracts/Deployment.t.sol
@@ -213,10 +213,6 @@ contract TestDeployer is MetadataDeployment {
         return abi.encodePacked(_creationCode, abi.encode(_addressesRegistry));
     }
 
-    function getBytecode(bytes memory _creationCode, address _addressesRegistry, address _governor) public pure returns (bytes memory) {
-        return abi.encodePacked(_creationCode, abi.encode(_addressesRegistry, _governor));
-    }
-
     function getBytecode(bytes memory _creationCode, address _addressesRegistry, uint256 _branchId) public pure returns (bytes memory) {
         return abi.encodePacked(_creationCode, abi.encode(_addressesRegistry, _branchId));
     }


### PR DESCRIPTION
`WrappedToken` is a modified contract of OZ's `ERC20Wrapper`. It stores the difference in decimals from 18 and applies it during deposit and withdrawal of underlying asset.

It is deployed in `DeployLiquity2.s.sol` for FBTC and SAGA and assigned as collaterals in their places.

NOTE: There were also duplicate `getBytecode` functions (with the governor address param) caused from previous PR merges that I removed to compile properly.