### PR TITLE
31 - Fix critical ratio inconsistencies in BorrowerOperations

### DIFF
--- a/contracts/test/TestContracts/BorrowerOperationsTester.t.sol
+++ b/contracts/test/TestContracts/BorrowerOperationsTester.t.sol
@@ -12,7 +12,7 @@ contract BorrowerOperationsTester is BorrowerOperations, IBorrowerOperationsTest
     constructor(IAddressesRegistry _addressesRegistry) BorrowerOperations(_addressesRegistry) {}
 
     function get_CCR() external view returns (uint256) {
-        return CCR;
+        return CCR();
     }
 
     function getCollToken() external view returns (IERC20) {


### PR DESCRIPTION
Changed immutable values CCR, SCR, MCR and BCR in `BorrowerOperations` to public functions that read from `addressesRegistry`. Fixes potential inconsistencies if one of those values were updated in the `AddressesRegistry` in its branch.