### PR TITLE
38 check branch active on new bold mint

### DIFF
--- a/contracts/src/BorrowerOperations.sol
+++ b/contracts/src/BorrowerOperations.sol
@@ -415,7 +415,8 @@ contract BorrowerOperations is LiquityBase, AddRemoveManagers, IBorrowerOperatio
     function withdrawBold(uint256 _troveId, uint256 _boldAmount, uint256 _maxUpfrontFee) external override {
         ITroveManager troveManagerCached = troveManager;
         _requireTroveIsActive(troveManagerCached, _troveId);
-
+        require(isBranchActive(), "BorrowerOperations: Branch is not active");
+        
         TroveChange memory troveChange;
         troveChange.debtIncrease = _boldAmount;
         _adjustTrove(troveManagerCached, _troveId, troveChange, _maxUpfrontFee);
@@ -467,6 +468,7 @@ contract BorrowerOperations is LiquityBase, AddRemoveManagers, IBorrowerOperatio
     ) external override {
         ITroveManager troveManagerCached = troveManager;
         _requireTroveIsActive(troveManagerCached, _troveId);
+        require(isBranchActive(), "BorrowerOperations: Branch is not active");
 
         TroveChange memory troveChange;
         _initTroveChange(troveChange, _collChange, _isCollIncrease, _boldChange, _isDebtIncrease);
@@ -485,6 +487,7 @@ contract BorrowerOperations is LiquityBase, AddRemoveManagers, IBorrowerOperatio
     ) external override {
         ITroveManager troveManagerCached = troveManager;
         _requireTroveIsZombie(troveManagerCached, _troveId);
+        require(isBranchActive(), "BorrowerOperations: Branch is not active");
 
         TroveChange memory troveChange;
         _initTroveChange(troveChange, _collChange, _isCollIncrease, _boldChange, _isDebtIncrease);
@@ -1614,5 +1617,9 @@ contract BorrowerOperations is LiquityBase, AddRemoveManagers, IBorrowerOperatio
         totalDebt -= _troveChange.debtDecrease;
 
         newTCR = LiquityMath._computeCR(totalColl, totalDebt, _price);
+    }
+
+    function isBranchActive() public view returns (bool) {
+        return troveManager.isActive();
     }
 }


### PR DESCRIPTION
I've got some test issues on this one, but none seem to be related or too serious.

```bash
Encountered 3 failing tests in test/interestBatchManagement.t.sol:InterestBatchManagementTest
[FAIL: TroveNotZombie()] testAnZombieTroveGoesBackToTheBatch() (gas: 1724984)
[FAIL: assertion failed: 1 != 4] testApplyBatchInterestPermissionlessReinsertsIntoSortedTrovesIfInBatch() (gas: 1255490)
[FAIL: next call did not revert as expected] testCannotSetBatchManagerIfTroveIsZombie() (gas: 1396588)

Encountered 1 failing test in test/interestIndividualDelegation.t.sol:InterestIndividualDelegationTest
[FAIL: A trove should be zombie: false != true] testSetDelegateRevertsIfTroveIsZombie() (gas: 1033447)

Encountered 3 failing tests in test/redemptions.t.sol:Redemptions
[FAIL: assertion failed: 1497402807884131374 >= 1100000000000000000] testZombieTroveCanBeLiquidated() (gas: 2681579)
[FAIL: NothingToLiquidate()] testZombieTrovePointerGetsResetIfTroveIsLiquidated() (gas: 2185851)
[FAIL: trove1 should have become lastZombieTroveId: 0 != 88925279229396141508971653401781720799474809066600592122859971296699369416787] testZombieTrovePointerIsPreservedIfItIsSkippedAndNoNewZombieIsProduced() (gas: 2935010)

Encountered 3 failing tests in test/zapperGasComp.t.sol:ZapperGasCompTest
[FAIL: TroveNotZombie()] testCanAdjustZombieTroveWithdrawCollAndBold() (gas: 1171142)
[FAIL: BOLD bal mismatch: 1000000000000000000000 != 199041095890410958905] testExcessRepaymentByAdjustGoesBackToUser() (gas: 1084178)
[FAIL: BOLD bal mismatch: 1000000000000000000000 != 199041095890410958905] testExcessRepaymentByRepayGoesBackToUser() (gas: 1047709)

Encountered 4 failing tests in test/zapperWETH.t.sol:ZapperWETHTest
[FAIL: TroveNotZombie()] testCanAdjustZombieTroveAddCollAndWithdrawBold() (gas: 1085427)
[FAIL: TroveNotZombie()] testCanAdjustZombieTroveWithdrawCollAndBold() (gas: 1049700)
[FAIL: BOLD bal mismatch: 1000000000000000000000 != 199041095890410958905] testExcessRepaymentByAdjustGoesBackToUser() (gas: 1049115)
[FAIL: BOLD bal mismatch: 1000000000000000000000 != 199041095890410958905] testExcessRepaymentByRepayGoesBackToUser() (gas: 1002008)

Encountered a total of 15 failing tests, 639 tests succeeded
```