### PR TITLE
12 - Replace getTroveManager with allTroveManagerAddresses in MultiTroveGetter and HintHelper

### DIFF
--- a/contracts/src/HintHelpers.sol
+++ b/contracts/src/HintHelpers.sol
@@ -36,7 +36,7 @@ contract HintHelpers is IHintHelpers {
         view
         returns (uint256 hintId, uint256 diff, uint256 latestRandomSeed)
     {
-        ITroveManager troveManager = collateralRegistry.getTroveManager(_collIndex);
+        ITroveManager troveManager = collateralRegistry.allTroveManagerAddresses(_collIndex);
         ISortedTroves sortedTroves = troveManager.sortedTroves();
 
         uint256 arrayLength = troveManager.getTroveIdsCount();
@@ -79,7 +79,7 @@ contract HintHelpers is IHintHelpers {
         view
         returns (uint256)
     {
-        ITroveManager troveManager = collateralRegistry.getTroveManager(_collIndex);
+        ITroveManager troveManager = collateralRegistry.allTroveManagerAddresses(_collIndex);
         IActivePool activePool = troveManager.activePool();
 
         TroveChange memory openTrove;
@@ -95,7 +95,7 @@ contract HintHelpers is IHintHelpers {
         view
         returns (uint256)
     {
-        ITroveManager troveManager = collateralRegistry.getTroveManager(_collIndex);
+        ITroveManager troveManager = collateralRegistry.allTroveManagerAddresses(_collIndex);
         IActivePool activePool = troveManager.activePool();
         LatestTroveData memory trove = troveManager.getLatestTroveData(_troveId);
 
@@ -114,7 +114,7 @@ contract HintHelpers is IHintHelpers {
         view
         returns (uint256)
     {
-        ITroveManager troveManager = collateralRegistry.getTroveManager(_collIndex);
+        ITroveManager troveManager = collateralRegistry.allTroveManagerAddresses(_collIndex);
         IActivePool activePool = troveManager.activePool();
         LatestTroveData memory trove = troveManager.getLatestTroveData(_troveId);
 
@@ -142,7 +142,7 @@ contract HintHelpers is IHintHelpers {
     {
         if (_debtIncrease == 0) return 0;
 
-        ITroveManager troveManager = collateralRegistry.getTroveManager(_collIndex);
+        ITroveManager troveManager = collateralRegistry.allTroveManagerAddresses(_collIndex);
         IActivePool activePool = troveManager.activePool();
         LatestTroveData memory trove = troveManager.getLatestTroveData(_troveId);
         (,,,,,,,, address batchManager,) = troveManager.Troves(_troveId);
@@ -172,7 +172,7 @@ contract HintHelpers is IHintHelpers {
         address _batchAddress,
         uint256 _newInterestRate
     ) external view returns (uint256) {
-        ITroveManager troveManager = collateralRegistry.getTroveManager(_collIndex);
+        ITroveManager troveManager = collateralRegistry.allTroveManagerAddresses(_collIndex);
         IActivePool activePool = troveManager.activePool();
         LatestBatchData memory batch = troveManager.getLatestBatchData(_batchAddress);
 
@@ -197,7 +197,7 @@ contract HintHelpers is IHintHelpers {
         view
         returns (uint256)
     {
-        ITroveManager troveManager = collateralRegistry.getTroveManager(_collIndex);
+        ITroveManager troveManager = collateralRegistry.allTroveManagerAddresses(_collIndex);
         IActivePool activePool = troveManager.activePool();
         LatestBatchData memory batch = troveManager.getLatestBatchData(_batchAddress);
 
@@ -217,7 +217,7 @@ contract HintHelpers is IHintHelpers {
         view
         returns (uint256)
     {
-        ITroveManager troveManager = collateralRegistry.getTroveManager(_collIndex);
+        ITroveManager troveManager = collateralRegistry.allTroveManagerAddresses(_collIndex);
         IActivePool activePool = troveManager.activePool();
         LatestTroveData memory trove = troveManager.getLatestTroveData(_troveId);
         LatestBatchData memory batch = troveManager.getLatestBatchData(_batchAddress);
@@ -238,7 +238,7 @@ contract HintHelpers is IHintHelpers {
         view
         returns (uint256)
     {
-        ITroveManager troveManager = collateralRegistry.getTroveManager(_collIndex);
+        ITroveManager troveManager = collateralRegistry.allTroveManagerAddresses(_collIndex);
         IActivePool activePool = troveManager.activePool();
         LatestTroveData memory trove = troveManager.getLatestTroveData(_troveId);
         (,,,,,,,, address batchManager,) = troveManager.Troves(_troveId);

--- a/contracts/src/Interfaces/ICollateralRegistry.sol
+++ b/contracts/src/Interfaces/ICollateralRegistry.sol
@@ -12,6 +12,7 @@ interface ICollateralRegistry {
     event CollateralRemoved(uint256 _branchId, address _token, address _troveManager);
     event CollateralDeletedForever(uint256 _branchId);
 
+    function allTroveManagerAddresses(uint256 _branchId) external view returns (ITroveManager);
     function isActiveCollateral(uint256 _branchId) external view returns (bool);
     function addCollateral(IERC20Metadata _token, ITroveManager _troveManager) external;
     function removeCollateral(uint256 _index) external;

--- a/contracts/src/MultiTroveGetter.sol
+++ b/contracts/src/MultiTroveGetter.sol
@@ -23,7 +23,7 @@ contract MultiTroveGetter is IMultiTroveGetter {
         view
         returns (CombinedTroveData[] memory _troves)
     {
-        ITroveManager troveManager = collateralRegistry.getTroveManager(_collIndex);
+        ITroveManager troveManager = collateralRegistry.allTroveManagerAddresses(_collIndex);
         require(address(troveManager) != address(0), "Invalid collateral index");
 
         ISortedTroves sortedTroves = troveManager.sortedTroves();
@@ -134,7 +134,7 @@ contract MultiTroveGetter is IMultiTroveGetter {
         view
         returns (DebtPerInterestRate[] memory data, uint256 currId)
     {
-        ITroveManager troveManager = collateralRegistry.getTroveManager(_collIndex);
+        ITroveManager troveManager = collateralRegistry.allTroveManagerAddresses(_collIndex);
         require(address(troveManager) != address(0), "Invalid collateral index");
 
         ISortedTroves sortedTroves = troveManager.sortedTroves();

--- a/contracts/test/basicOps.t.sol
+++ b/contracts/test/basicOps.t.sol
@@ -5,6 +5,9 @@ pragma solidity 0.8.24;
 import "./TestContracts/DevTestSetup.sol";
 import "./TestContracts/ERC20Faucet.sol";
 import "./TestContracts/CollateralRegistryTester.sol";
+import "../src/MultiTroveGetter.sol";
+import "../src/Interfaces/IMultiTroveGetter.sol";
+import "../src/HintHelpers.sol";
 
 contract BasicOps is DevTestSetup {
     function testOpenTroveFailsWithoutAllowance() public {
@@ -278,5 +281,70 @@ contract BasicOps is DevTestSetup {
         removedBranchIds = myCollateralRegistry.removedBranchIds();
         assertEq(removedBranchIds.length, 1);
         assertEq(removedBranchIds[0], 1);
+    }
+
+    function testMultiTroveGetterBranchIdAfterRemoval() public {
+        IERC20Metadata[] memory tokens = new IERC20Metadata[](2);
+        tokens[0] = new ERC20Faucet("Test", "TEST", 100 ether, 1 days);
+        tokens[1] = new ERC20Faucet("Test", "TEST", 100 ether, 1 days);
+        ITroveManager[] memory troveManagers = new ITroveManager[](2);
+        troveManagers[0] = new TroveManager(addressesRegistry, 0);
+        troveManagers[1] = new TroveManager(addressesRegistry, 1);
+
+        // Deploy a new collateral registry
+        CollateralRegistry myCollateralRegistry = new CollateralRegistryTester(boldToken, tokens, troveManagers, address(0x123));
+
+        priceFeed.setPrice(2000e18);
+        vm.prank(A);
+        borrowerOperations.openTrove(
+            A, 0, 2e18, 2000e18, 0, 0, MIN_ANNUAL_INTEREST_RATE, 1000e18, address(0), address(0), address(0)
+        );
+
+        vm.prank(address(0x123));
+        myCollateralRegistry.removeCollateral(1);
+
+        uint256[] memory removedBranchIds = myCollateralRegistry.removedBranchIds();
+        assertEq(removedBranchIds.length, 1);
+        assertEq(removedBranchIds[0], 1);
+
+        MultiTroveGetter multiTroveGetter = new MultiTroveGetter(myCollateralRegistry);
+        IMultiTroveGetter.CombinedTroveData[] memory _troves = multiTroveGetter.getMultipleSortedTroves(1, 0, 1);
+        assertEq(_troves.length, 1);
+
+
+        vm.expectRevert("Invalid collateral index");
+        multiTroveGetter.getMultipleSortedTroves(2, 0, 1);
+    }
+
+    function testHintHelpersBranchIdAfterRemoval() public {
+        IERC20Metadata[] memory tokens = new IERC20Metadata[](2);
+        tokens[0] = new ERC20Faucet("Test", "TEST", 100 ether, 1 days);
+        tokens[1] = new ERC20Faucet("Test", "TEST", 100 ether, 1 days);
+        ITroveManager[] memory troveManagers = new ITroveManager[](2);
+        troveManagers[0] = new TroveManager(addressesRegistry, 0);
+        troveManagers[1] = new TroveManager(addressesRegistry, 1);
+
+        // Deploy a new collateral registry
+        CollateralRegistry myCollateralRegistry = new CollateralRegistryTester(boldToken, tokens, troveManagers, address(0x123));
+        
+        priceFeed.setPrice(2000e18);
+        vm.prank(A);
+        borrowerOperations.openTrove(
+            A, 0, 2e18, 2000e18, 0, 0, MIN_ANNUAL_INTEREST_RATE, 1000e18, address(0), address(0), address(0)
+        );
+
+
+        vm.prank(address(0x123));
+        myCollateralRegistry.removeCollateral(1);
+
+        uint256[] memory removedBranchIds = myCollateralRegistry.removedBranchIds();
+        assertEq(removedBranchIds.length, 1);
+        assertEq(removedBranchIds[0], 1);
+
+        HintHelpers hintHelpers = new HintHelpers(myCollateralRegistry);
+        hintHelpers.predictOpenTroveUpfrontFee(1, 100e18, 1000e18);
+
+        vm.expectRevert();
+        hintHelpers.predictOpenTroveUpfrontFee(2, 100e18, 1000e18);
     }
 }


### PR DESCRIPTION
The `MultiTroveGetter` and `HintHelper` rely on the branchId rather than the array index of active branches when trying to fetch the TroveManager address. This changes the use of `getTroveManager` function with `allTroveManagerAddresses` in those contracts to get the correct TroveManager by branchId.