### PR TITLE
18 - Initialize branches in collateral registry

### DIFF
--- a/contracts/src/CollateralRegistry.sol
+++ b/contracts/src/CollateralRegistry.sol
@@ -66,6 +66,8 @@ contract CollateralRegistry is ICollateralRegistry {
             _activeBranchIds.push(i);
         }
 
+        branches = numTokens;
+
         // Initialize the baseRate state variable
         baseRate = INITIAL_BASE_RATE;
         emit BaseRateUpdated(INITIAL_BASE_RATE);


### PR DESCRIPTION
`branches` needs to be initialized in constructor. Otherwise, `addCollateral` will break.