### PR TITLE
Resolve L-02 (Audit #2, Issue #5): Require active branch in withdrawColl

### DIFF
--- a/contracts/src/BorrowerOperations.sol
+++ b/contracts/src/BorrowerOperations.sol
@@ -404,6 +404,7 @@ contract BorrowerOperations is LiquityBase, AddRemoveManagers, IBorrowerOperatio
     function withdrawColl(uint256 _troveId, uint256 _collWithdrawal) external override {
         ITroveManager troveManagerCached = troveManager;
         _requireTroveIsActive(troveManagerCached, _troveId);
+        require(isBranchActive(), "BorrowerOperations: Branch is not active");
 
         TroveChange memory troveChange;
         troveChange.collDecrease = _collWithdrawal;

--- a/contracts/test/borrowerOperations.t.sol
+++ b/contracts/test/borrowerOperations.t.sol
@@ -39,6 +39,15 @@ contract BorrowerOperationsTest is DevTestSetup {
         borrowerOperations.withdrawColl(troveId, 200 ether);
     }
 
+    function testWithdrawingCollateralRevertsIfBranchIsNotActive() public {
+        uint256 troveId = openTroveNoHints100pct(A, 100 ether, 2_000 ether, 0.01 ether);
+        vm.prank(governor);
+        collateralRegistry.removeCollateral(0);
+        vm.prank(A);
+        vm.expectRevert("BorrowerOperations: Branch is not active");
+        borrowerOperations.withdrawColl(troveId, 50 ether);
+    }
+
     function testZeroAdjustmentReverts() public {
         uint256 troveId = openTroveNoHints100pct(A, 100 ether, 2_000 ether, 0.01 ether);
         vm.prank(A);


### PR DESCRIPTION
Added a constraint in `withdrawColl` function to require branch is active.

In a removed branch, the only way a user can withdraw their collateral is by closing their trove.