### PR TITLE
Resolve L-04 (Audit #2, Issue #9): Mark _getCollGasCompensation from pure to view function

### DIFF
--- a/contracts/src/TroveManager.sol
+++ b/contracts/src/TroveManager.sol
@@ -369,7 +369,7 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
     }
 
     // Return the amount of Coll to be drawn from a trove's collateral and sent as gas compensation.
-    function _getCollGasCompensation(uint256 _coll) internal pure returns (uint256) {
+    function _getCollGasCompensation(uint256 _coll) internal view returns (uint256) {
         // _entireDebt should never be zero, but we add the condition defensively to avoid an unexpected revert
         return LiquityMath._min(_coll / COLL_GAS_COMPENSATION_DIVISOR, gasCompensationMaxReward);
     }

--- a/contracts/test/TestContracts/TroveManagerTester.t.sol
+++ b/contracts/test/TestContracts/TroveManagerTester.t.sol
@@ -105,7 +105,7 @@ contract TroveManagerTester is ITroveManagerTester, TroveManager {
 
     function getCollGasCompensation(uint256 _entireColl, uint256 _entireDebt, uint256 _boldInSPForOffsets)
         external
-        pure
+        view
         returns (uint256)
     {
         uint256 collSubjectToGasCompensation = _entireColl;
@@ -115,7 +115,7 @@ contract TroveManagerTester is ITroveManagerTester, TroveManager {
         return _getCollGasCompensation(collSubjectToGasCompensation);
     }
 
-    function getCollGasCompensation(uint256 _coll) external pure returns (uint256) {
+    function getCollGasCompensation(uint256 _coll) external view returns (uint256) {
         return _getCollGasCompensation(_coll);
     }
 


### PR DESCRIPTION
Changed `_getCollGasCompensation(uint256 _coll)` from `pure` to `view`.

`contracts/src` successfully compiles now.