### PR TITLE
Resolve L-07 (Audit #2, Issue #15): Add token match validation in addCollateral function

### DIFF
--- a/contracts/src/CollateralRegistry.sol
+++ b/contracts/src/CollateralRegistry.sol
@@ -385,6 +385,7 @@ contract CollateralRegistry is ICollateralRegistry {
         //validate input
         require(address(_token) != address(0), "CollateralRegistry: Token cannot be address(0)");
         require(address(_troveManager) != address(0), "CollateralRegistry: TroveManager cannot be address(0)");
+        require(address(_token) == address(_troveManager.addressesRegistry().collToken()), "CollateralRegistry: Token does not match TroveManager collateral token");
 
         uint256 branchId = _troveManager.branchId();
         require(branchId == branches, "CollateralRegistry: TroveManager branchId does not match master index");


### PR DESCRIPTION
Added a check to prevent mismatch of `_token` and collateral token of `_troveManager` in `addCollateral` function.

Modified and added unit tests `testAddCollateral` and `testAddCollateralRevertsIfTokenDoesNotMatchTroveManagerCollateralToken` in `basicOps.t.sol` to test this change.