### PR TITLE
Resolve L-08 (Audit #2, Issue #16): Delete _resolve override function in WrappedToken

### DIFF
--- a/contracts/src/ERC20Wrappers/WrappedToken.sol
+++ b/contracts/src/ERC20Wrappers/WrappedToken.sol
@@ -45,14 +45,4 @@ contract WrappedToken is ERC20Wrapper {
         underlying().safeTransfer(account, amount / 10**_decimalDiff);
         return true;
     }
-
-    /**
-     * @dev Mint wrapped token to cover any underlyingTokens that would have been transferred by mistake. Internal
-     * function that can be exposed with access control if desired.
-     */
-    function _recover(address account) internal virtual override returns (uint256) {
-        uint256 value = underlying().balanceOf(address(this)) - totalSupply();
-        _mint(account, value * 10**_decimalDiff);
-        return value;
-    }
 }


### PR DESCRIPTION
Removed unused `_resolve(address account)` internal override function from `WrappedToken`.

The `WrappedToken` is not expected to be used outside the protocol nor will users likely interacted with it directly. Instead, a zapper contract similar to the `WETHZapper` will call the `WrappedToken` on behalf of the user to wrap their tokens while opening their trove and unwrap them while closing or withdrawing collateral from their trove. Thus, a recovery function seems unnecessary to include for an extremely unlikely scenario.