### PR TITLE
Resolve L-09 (Audit #2, Issue #23): Add validations on hierarchy of CRs in AddressesRegistry

### DIFF
--- a/contracts/src/AddressesRegistry.sol
+++ b/contracts/src/AddressesRegistry.sol
@@ -85,8 +85,8 @@ contract AddressesRegistry is Ownable, IAddressesRegistry {
         uint256 _liquidationPenaltySP,
         uint256 _liquidationPenaltyRedistribution
     ) Ownable(_owner) {
-        if (_ccr <= 1e18 || _ccr >= 5e18) revert InvalidCCR();
-        if (_mcr <= 1e18 || _mcr >= 5e18) revert InvalidMCR();
+        if (_ccr <= 1e18 || _ccr >= 5e18 || _ccr <= _scr || _ccr <= _mcr) revert InvalidCCR();
+        if (_mcr <= 1e18 || _mcr >= 5e18 || _mcr < _scr) revert InvalidMCR();
         if (_bcr < 5e16 || _bcr >= 50e16) revert InvalidBCR();
         if (_scr <= 1e18 || _scr >= 5e18) revert InvalidSCR();
         if (_liquidationPenaltySP < MIN_LIQUIDATION_PENALTY_SP) revert SPPenaltyTooLow();
@@ -146,14 +146,14 @@ contract AddressesRegistry is Ownable, IAddressesRegistry {
 
     function updateCCR(uint256 _newCCR) external {
         require(msg.sender == address(collateralRegistry), "AddressesRegistry: Only collateral registry can call this function");
-        if (_newCCR <= 1e18 || _newCCR >= 5e18) revert InvalidCCR();
+        if (_newCCR <= 1e18 || _newCCR >= 5e18 || _newCCR <= SCR || _newCCR <= MCR) revert InvalidCCR();
         CCR = _newCCR;
         emit CCRUpdated(_newCCR);
     }
 
     function updateMCR(uint256 _newMCR) external {
         require(msg.sender == address(collateralRegistry), "AddressesRegistry: Only collateral registry can call this function");
-        if (_newMCR <= 1e18 || _newMCR >= 5e18) revert InvalidMCR();
+        if (_newMCR <= 1e18 || _newMCR >= 5e18 || _newMCR < SCR || _newMCR >= CCR) revert InvalidMCR();
         MCR = _newMCR;
         emit MCRUpdated(_newMCR);
     }
@@ -167,7 +167,7 @@ contract AddressesRegistry is Ownable, IAddressesRegistry {
 
     function updateSCR(uint256 _newSCR) external {
         require(msg.sender == address(collateralRegistry), "AddressesRegistry: Only collateral registry can call this function");
-        if (_newSCR <= 1e18 || _newSCR >= 5e18) revert InvalidSCR();
+        if (_newSCR <= 1e18 || _newSCR >= 5e18 || _newSCR >= CCR || _newSCR > MCR) revert InvalidSCR();
         SCR = _newSCR;
         emit SCRUpdated(_newSCR);
     }


### PR DESCRIPTION
Add additional checks in `constructor`, `updateCCR`, `updateMCR` and `updateSCR` to validate all 3 values `CCR`, `MCR` and `SCR` follow the hierarchy: CCR > MCR >= SCR.