### PR TITLE
Resolve L-12 (Audit #2, Issue #26): Update token and NFT metadata to MUST/Mustang

### DIFF
--- a/contracts/src/BoldToken.sol
+++ b/contracts/src/BoldToken.sol
@@ -17,8 +17,8 @@ import "./Interfaces/IBoldToken.sol";
  */
 
 contract BoldToken is Ownable, IBoldToken, ERC20Permit {
-    string internal constant _NAME = "BOLD Stablecoin";
-    string internal constant _SYMBOL = "BOLD";
+    string internal constant _NAME = "MUST Stablecoin";
+    string internal constant _SYMBOL = "MUST";
 
     // --- Addresses ---
 

--- a/contracts/src/NFTMetadata/MetadataNFT.sol
+++ b/contracts/src/NFTMetadata/MetadataNFT.sol
@@ -36,11 +36,11 @@ contract MetadataNFT is IMetadataNFT {
     function uri(TroveData memory _troveData) public view returns (string memory) {
         string memory attr = attributes(_troveData);
         return json.formattedMetadata(
-            string.concat("Liquity V2 - ", IERC20Metadata(_troveData._collToken).name()),
+            string.concat("Mustang - ", IERC20Metadata(_troveData._collToken).name()),
             string.concat(
-                "Liquity V2 is a collateralized debt platform. Users can lock up ",
+                "Mustang is a collateralized debt platform. Users can lock up ",
                 IERC20Metadata(_troveData._collToken).symbol(),
-                " to issue stablecoin tokens (BOLD) to their own Ethereum address. The individual collateralized debt positions are called Troves, and are represented as NFTs."
+                " to issue stablecoin tokens (MUST) to their own Ethereum address. The individual collateralized debt positions are called Troves, and are represented as NFTs."
             ),
             renderSVGImage(_troveData),
             attr


### PR DESCRIPTION
Replace "BOLD" and "Liquity V2" references in `BoldToken` and `MetadataNFT` metadata to "MUST" and "Mustang" respectively.