### PR TITLE
Resolve M-03 (Audit #2, Issue #39): Conditionally require active branch in adjustTrove

### DIFF
--- a/contracts/src/BorrowerOperations.sol
+++ b/contracts/src/BorrowerOperations.sol
@@ -473,7 +473,10 @@ contract BorrowerOperations is LiquityBase, AddRemoveManagers, IBorrowerOperatio
     ) external override {
         ITroveManager troveManagerCached = troveManager;
         _requireTroveIsActive(troveManagerCached, _troveId);
-        require(isBranchActive(), "BorrowerOperations: Branch is not active");
+        // Branch must be active if user is issuing more debt and/or withdrawing collateral
+        if (_isDebtIncrease || !_isCollIncrease) {
+            require(isBranchActive(), "BorrowerOperations: Branch is not active");
+        }
 
         TroveChange memory troveChange;
         _initTroveChange(troveChange, _collChange, _isCollIncrease, _boldChange, _isDebtIncrease);


### PR DESCRIPTION
In the `adjustTrove` function in `BorrowerOperations`, I changed the active branch require to be conditionally enforced like so:
```solidity
// Branch must be active if user is issuing more debt and/or withdrawing collateral
if (_isDebtIncrease || !_isCollIncrease) {
    require(isBranchActive(), "BorrowerOperations: Branch is not active");
}
```

This follows the same rule as PR #45 in which a user cannot issue more debt nor withdraw collateral from an existing trove in a removed branch.

**Changes that were considered but decided not to do:**
1. Apply same change in `adjustZombieTrove` function. Reason: a trove becomes a zombie trove once its debt falls below the minimum debt requirement. Since new debt cannot be issued in a removed branch and the existing debt cannot be repaid below the minimum debt amount, it would not make sense to adjust it.
2. Moving `_requireIsNotShutDown` validation in the `_adjustTrove` function. Reason: this is an original Liquity V2 piece of logic. Users can still repay while branch is shutdown, regardless if active or removed, by closing their trove.