### PR TITLE
Change MainnetPriceFeedBase to assert 8 or 18 decimals

### DIFF
--- a/contracts/src/PriceFeeds/MainnetPriceFeedBase.sol
+++ b/contracts/src/PriceFeeds/MainnetPriceFeedBase.sol
@@ -47,7 +47,7 @@ abstract contract MainnetPriceFeedBase is IMainnetPriceFeed {
 
         borrowerOperations = IBorrowerOperations(_borrowOperationsAddress);
 
-        assert(ethUsdOracle.decimals == 8);
+        assert(ethUsdOracle.decimals == 8 || ethUsdOracle.decimals == 18);
     }
 
     function _getOracleAnswer(Oracle memory _oracle) internal view returns (uint256, bool) {


### PR DESCRIPTION
Only `WETHPriceFeed` inherits `MainnetPriceFeedBase` and its oracle has 18 decimals so updated the assertion to include 18 decimals.

No other changes in this contract needed.