### PR TITLE
Update and prepare subgraph for deployment

### DIFF
--- a/subgraph/networks.json
+++ b/subgraph/networks.json
@@ -7,6 +7,12 @@
       "address": "0x79fdb65c20e75f8961d54f6714d2fcc4c30d1073"
     }
   },
+  "saga-evm": {
+    "BoldToken": {
+      "address": "0x6afc1dc17a4dac310e84100578fa8f0699cd43b9",
+      "startBlock": 5063018
+    }
+  },
   "mainnet": {
     "BoldToken": {
       "address": "0x6440f144b7e50d6a8439336510312d2f54beb01d",

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -4,7 +4,9 @@
   "license": "MIT",
   "version": "1.0.0",
   "scripts": {
-    "codegen": "pnpm graph codegen"
+    "codegen": "pnpm graph codegen",
+    "build": "pnpm graph build",
+    "deploy": "goldsky subgraph deploy --path ./build"
   },
   "devDependencies": {
     "@graphprotocol/graph-cli": "^0.97.0"

--- a/subgraph/src/TroveManager.mapping.ts
+++ b/subgraph/src/TroveManager.mapping.ts
@@ -1,7 +1,7 @@
 import { Address, BigInt, Bytes, dataSource, ethereum } from "@graphprotocol/graph-ts";
 import { InterestBatch, InterestRateBracket, Trove } from "../generated/schema";
 import {
-  BatchedTroveUpdated as BatchedTroveUpdatedEvent,
+  // BatchedTroveUpdated as BatchedTroveUpdatedEvent,
   BatchUpdated as BatchUpdatedEvent,
   TroveOperation as TroveOperationEvent,
   TroveUpdated as TroveUpdatedEvent,
@@ -52,48 +52,48 @@ function decodeUint256(data: Bytes, i: i32 = 0): ethereum.Value {
   );
 }
 
-function getBatchUpdatedEventFrom(batchedTroveUpdatedEvent: BatchedTroveUpdatedEvent): BatchUpdatedEvent {
-  let receipt = batchedTroveUpdatedEvent.receipt;
+// function getBatchUpdatedEventFrom(batchedTroveUpdatedEvent: BatchedTroveUpdatedEvent): BatchUpdatedEvent {
+//   let receipt = batchedTroveUpdatedEvent.receipt;
 
-  if (!receipt) {
-    throw new Error("Missing TX receipt");
-  }
+//   if (!receipt) {
+//     throw new Error("Missing TX receipt");
+//   }
 
-  let batchUpdatedLogIndex = -1;
+//   let batchUpdatedLogIndex = -1;
 
-  for (let i = 0; i < receipt.logs.length; ++i) {
-    if (receipt.logs[i].logIndex.equals(batchedTroveUpdatedEvent.logIndex.plus(BigInt.fromI32(2)))) {
-      batchUpdatedLogIndex = i;
-      break;
-    }
-  }
+//   for (let i = 0; i < receipt.logs.length; ++i) {
+//     if (receipt.logs[i].logIndex.equals(batchedTroveUpdatedEvent.logIndex.plus(BigInt.fromI32(2)))) {
+//       batchUpdatedLogIndex = i;
+//       break;
+//     }
+//   }
 
-  if (batchUpdatedLogIndex < 0) {
-    throw new Error("Missing BatchUpdated log");
-  }
+//   if (batchUpdatedLogIndex < 0) {
+//     throw new Error("Missing BatchUpdated log");
+//   }
 
-  let batchUpdatedLog = receipt.logs[batchUpdatedLogIndex];
+//   let batchUpdatedLog = receipt.logs[batchUpdatedLogIndex];
 
-  return new BatchUpdatedEvent(
-    batchUpdatedLog.address,
-    batchUpdatedLog.logIndex,
-    batchUpdatedLog.transactionLogIndex,
-    batchUpdatedLog.logType,
-    batchedTroveUpdatedEvent.block,
-    batchedTroveUpdatedEvent.transaction,
-    [
-      new ethereum.EventParam("_interestBatchManager", decodeAddress(batchUpdatedLog.topics[1])),
-      new ethereum.EventParam("_operation", decodeUint8(batchUpdatedLog.data, 0)),
-      new ethereum.EventParam("_debt", decodeUint256(batchUpdatedLog.data, 1)),
-      new ethereum.EventParam("_coll", decodeUint256(batchUpdatedLog.data, 2)),
-      new ethereum.EventParam("_annualInterestRate", decodeUint256(batchUpdatedLog.data, 3)),
-      new ethereum.EventParam("_annualManagementFee", decodeUint256(batchUpdatedLog.data, 4)),
-      new ethereum.EventParam("_totalDebtShares", decodeUint256(batchUpdatedLog.data, 5)),
-      new ethereum.EventParam("_debtIncreaseFromUpfrontFee", decodeUint256(batchUpdatedLog.data, 6)),
-    ],
-    batchedTroveUpdatedEvent.receipt,
-  );
-}
+//   return new BatchUpdatedEvent(
+//     batchUpdatedLog.address,
+//     batchUpdatedLog.logIndex,
+//     batchUpdatedLog.transactionLogIndex,
+//     batchUpdatedLog.logType,
+//     batchedTroveUpdatedEvent.block,
+//     batchedTroveUpdatedEvent.transaction,
+//     [
+//       new ethereum.EventParam("_interestBatchManager", decodeAddress(batchUpdatedLog.topics[1])),
+//       new ethereum.EventParam("_operation", decodeUint8(batchUpdatedLog.data, 0)),
+//       new ethereum.EventParam("_debt", decodeUint256(batchUpdatedLog.data, 1)),
+//       new ethereum.EventParam("_coll", decodeUint256(batchUpdatedLog.data, 2)),
+//       new ethereum.EventParam("_annualInterestRate", decodeUint256(batchUpdatedLog.data, 3)),
+//       new ethereum.EventParam("_annualManagementFee", decodeUint256(batchUpdatedLog.data, 4)),
+//       new ethereum.EventParam("_totalDebtShares", decodeUint256(batchUpdatedLog.data, 5)),
+//       new ethereum.EventParam("_debtIncreaseFromUpfrontFee", decodeUint256(batchUpdatedLog.data, 6)),
+//     ],
+//     batchedTroveUpdatedEvent.receipt,
+//   );
+// }
 
 export function handleTroveUpdated(event: TroveUpdatedEvent): void {
   let collId = dataSource.context().getString("collId");
@@ -124,39 +124,39 @@ export function handleTroveUpdated(event: TroveUpdatedEvent): void {
   trove.save();
 }
 
-export function handleBatchedTroveUpdated(batchedTroveUpdatedEvent: BatchedTroveUpdatedEvent): void {
-  let batchUpdatedEvent = getBatchUpdatedEventFrom(batchedTroveUpdatedEvent);
-  let collId = dataSource.context().getString("collId");
-  let troveId = batchedTroveUpdatedEvent.params._troveId;
-  let troveFullId = collId + ":" + troveId.toHexString();
-  let trove = Trove.load(troveFullId);
+// export function handleBatchedTroveUpdated(batchedTroveUpdatedEvent: BatchedTroveUpdatedEvent): void {
+//   let batchUpdatedEvent = getBatchUpdatedEventFrom(batchedTroveUpdatedEvent);
+//   let collId = dataSource.context().getString("collId");
+//   let troveId = batchedTroveUpdatedEvent.params._troveId;
+//   let troveFullId = collId + ":" + troveId.toHexString();
+//   let trove = Trove.load(troveFullId);
 
-  if (!trove) {
-    throw new Error("Trove not found: " + troveFullId);
-  }
+//   if (!trove) {
+//     throw new Error("Trove not found: " + troveFullId);
+//   }
 
-  updateRateBracketDebt(
-    collId,
-    trove.interestRate,
-    BigInt.zero(),
-    trove.debt,
-    BigInt.zero(), // batched debt handled at batch level
-    trove.updatedAt,
-    batchedTroveUpdatedEvent.block.timestamp,
-  );
+//   updateRateBracketDebt(
+//     collId,
+//     trove.interestRate,
+//     BigInt.zero(),
+//     trove.debt,
+//     BigInt.zero(), // batched debt handled at batch level
+//     trove.updatedAt,
+//     batchedTroveUpdatedEvent.block.timestamp,
+//   );
 
-  trove.debt = batchUpdatedEvent.params._totalDebtShares.notEqual(BigInt.zero())
-    ? batchUpdatedEvent.params._debt
-      .times(batchedTroveUpdatedEvent.params._batchDebtShares)
-      .div(batchUpdatedEvent.params._totalDebtShares)
-    : BigInt.zero();
-  trove.deposit = batchedTroveUpdatedEvent.params._coll;
-  trove.stake = batchedTroveUpdatedEvent.params._stake;
-  trove.interestRate = BigInt.zero();
-  trove.interestBatch = collId + ":" + batchedTroveUpdatedEvent.params._interestBatchManager.toHexString();
-  trove.updatedAt = batchedTroveUpdatedEvent.block.timestamp;
-  trove.save();
-}
+//   trove.debt = batchUpdatedEvent.params._totalDebtShares.notEqual(BigInt.zero())
+//     ? batchUpdatedEvent.params._debt
+//       .times(batchedTroveUpdatedEvent.params._batchDebtShares)
+//       .div(batchUpdatedEvent.params._totalDebtShares)
+//     : BigInt.zero();
+//   trove.deposit = batchedTroveUpdatedEvent.params._coll;
+//   trove.stake = batchedTroveUpdatedEvent.params._stake;
+//   trove.interestRate = BigInt.zero();
+//   trove.interestBatch = collId + ":" + batchedTroveUpdatedEvent.params._interestBatchManager.toHexString();
+//   trove.updatedAt = batchedTroveUpdatedEvent.block.timestamp;
+//   trove.save();
+// }
 
 export function handleTroveOperation(event: TroveOperationEvent): void {
   let collId = dataSource.context().getString("collId");

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -6,8 +6,8 @@ dataSources:
     name: BoldToken
     source:
       abi: BoldToken
-      address: "0x6440f144b7e50d6a8439336510312d2f54beb01d"
-      startBlock: 22483043
+      address: "0x6afc1dc17a4dac310e84100578fa8f0699cd43b9"
+      startBlock: 5063018
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.9
@@ -32,41 +32,41 @@ dataSources:
         - event: CollateralRegistryAddressChanged(address)
           handler: handleCollateralRegistryAddressChanged
       file: ./src/BoldToken.mapping.ts
-    network: mainnet
-  - kind: ethereum/contract
-    name: Governance
-    source:
-      abi: Governance
-      address: "0x807def5e7d057df05c796f4bc75c3fe82bd6eee1"
-      startBlock: 22496547
-    mapping:
-      kind: ethereum/events
-      apiVersion: 0.0.9
-      language: wasm/assemblyscript
-      entities:
-        - GovernanceAllocation
-        - GovernanceInitiative
-        - GovernanceUser
-      abis:
-        - name: Governance
-          file: ../contracts/out/Governance.sol/Governance.json
-      eventHandlers:
-        - event: DepositLQTY(indexed
-            address,address,uint256,uint256,uint256,uint256,uint256)
-          handler: handleDepositLQTY
-        - event: WithdrawLQTY(indexed
-            address,address,uint256,uint256,uint256,uint256,uint256,uint256)
-          handler: handleWithdrawLQTY
-        - event: AllocateLQTY(indexed address,indexed address,int256,int256,uint256,uint8)
-          handler: handleAllocateLQTY
-        - event: RegisterInitiative(address,address,uint256,uint8)
-          handler: handleRegisterInitiative
-      file: ./src/Governance.mapping.ts
-    network: mainnet
+    network: saga-evm
+  # - kind: ethereum/contract
+  #   name: Governance
+  #   source:
+  #     abi: Governance
+  #     address: "0x807def5e7d057df05c796f4bc75c3fe82bd6eee1"
+  #     startBlock: 22496547
+  #   mapping:
+  #     kind: ethereum/events
+  #     apiVersion: 0.0.9
+  #     language: wasm/assemblyscript
+  #     entities:
+  #       - GovernanceAllocation
+  #       - GovernanceInitiative
+  #       - GovernanceUser
+  #     abis:
+  #       - name: Governance
+  #         file: ../contracts/out/Governance.sol/Governance.json
+  #     eventHandlers:
+  #       - event: DepositLQTY(indexed
+  #           address,address,uint256,uint256,uint256,uint256,uint256)
+  #         handler: handleDepositLQTY
+  #       - event: WithdrawLQTY(indexed
+  #           address,address,uint256,uint256,uint256,uint256,uint256,uint256)
+  #         handler: handleWithdrawLQTY
+  #       - event: AllocateLQTY(indexed address,indexed address,int256,int256,uint256,uint8)
+  #         handler: handleAllocateLQTY
+  #       - event: RegisterInitiative(address,address,uint256,uint8)
+  #         handler: handleRegisterInitiative
+  #     file: ./src/Governance.mapping.ts
+  #   network: saga-evm
 templates:
   - name: TroveManager
     kind: ethereum/contract
-    network: mainnet
+    network: saga-evm
     source:
       abi: TroveManager
     mapping:
@@ -93,16 +93,16 @@ templates:
         - event: TroveUpdated(indexed
             uint256,uint256,uint256,uint256,uint256,uint256,uint256)
           handler: handleTroveUpdated
-        - event: BatchedTroveUpdated(indexed
-            uint256,address,uint256,uint256,uint256,uint256,uint256)
-          handler: handleBatchedTroveUpdated
+        # - event: BatchedTroveUpdated(indexed
+        #     uint256,address,uint256,uint256,uint256,uint256,uint256)
+        #   handler: handleBatchedTroveUpdated
           receipt: true
         - event: BatchUpdated(indexed
             address,uint8,uint256,uint256,uint256,uint256,uint256,uint256)
           handler: handleBatchUpdated
   - name: TroveNFT
     kind: ethereum/contract
-    network: mainnet
+    network: saga-evm
     source:
       abi: TroveNFT
     mapping:


### PR DESCRIPTION
Removed `BatchedTroveUpdated` event handler (currently commented out) since it is no longer used in contracts.

Made a test deployment on Goldsky and included scripts in `package.json` to repeat deployment process for future reference.