### PR TITLE
Revert SAGA and STATOM debt limits to original $1M values

### DIFF
--- a/contracts/src/Dependencies/Constants.sol
+++ b/contracts/src/Dependencies/Constants.sol
@@ -50,8 +50,8 @@ uint256 constant BCR_ALL = 10 * _1pct;
 uint256 constant WETH_DEBT_LIMIT = 100_000_000e18;
 uint256 constant YETH_DEBT_LIMIT = 5_000_000e18;
 uint256 constant TBTC_DEBT_LIMIT = 100_000_000e18;
-uint256 constant SAGA_DEBT_LIMIT = 1_000_000_000e18; // 1 billion - effectively unlimited
-uint256 constant STATOM_DEBT_LIMIT = 1_000_000_000e18; // 1 billion - effectively unlimited
+uint256 constant SAGA_DEBT_LIMIT = 1_000_000e18;
+uint256 constant STATOM_DEBT_LIMIT = 1_000_000e18;
 uint256 constant KING_DEBT_LIMIT = 500_000e18;
 uint256 constant YUSD_DEBT_LIMIT = 5_000_000e18;
 

--- a/frontend/app/src/constants.ts
+++ b/frontend/app/src/constants.ts
@@ -81,8 +81,8 @@ export const MAX_DEBT_LIMITS: Record<CollateralSymbol, dn.Dnum> = {
   TBTC: dn.from(100_000_000n, 18),
   YETH: dn.from(5_000_000n, 18),
   YUSD: dn.from(5_000_000n, 18),
-  SAGA: dn.from(1_000_000_000n, 18), // 1 billion - effectively unlimited
-  STATOM: dn.from(1_000_000_000n, 18), // 1 billion - effectively unlimited
+  SAGA: dn.from(1_000_000n, 18),
+  STATOM: dn.from(1_000_000n, 18),
   KING: dn.from(500_000n, 18),
 };
 


### PR DESCRIPTION
Reverts the debt limits from $1B back to $1M for SAGA and STATOM to fix the 100x 