### PR TITLE
Add Points Badge with Decoupled Service Architecture

### DIFF
--- a/frontend/app/src/comps/AppLayout/PointsBadge.tsx
+++ b/frontend/app/src/comps/AppLayout/PointsBadge.tsx
@@ -1,0 +1,109 @@
+import { css } from "@/styled-system/css";
+import { formatXP } from "@/src/formatting";
+import { useUserPoints } from "@/src/services/Points";
+import { ConnectKitButton } from "connectkit";
+import { useState } from "react";
+
+export function PointsBadge() {
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  return (
+    <ConnectKitButton.Custom>
+      {({ isConnected, address }) => {
+        const { data: points } = useUserPoints(isConnected ? address : null);
+
+        if (!isConnected) return null;
+
+        return (
+          <div
+            className={css({
+              position: "relative",
+              display: "flex",
+              alignItems: "center",
+            })}
+            onMouseEnter={() => setShowTooltip(true)}
+            onMouseLeave={() => setShowTooltip(false)}
+          >      
+            <div
+              className={`font-audiowide ${css({
+                display: "flex",
+                alignItems: "center",
+                gap: 4,
+                height: "25px",
+                padding: "0 12px",
+                background: "#A189AB",
+                color: "white",
+                borderRadius: "9999px",
+                fontSize: "11px",
+                fontWeight: 600,
+                cursor: "default",
+                transition: "all 0.2s",
+                whiteSpace: "nowrap",
+                "&:hover": {
+                  transform: "translateY(-2px)",
+                },
+              })}`}
+            >
+              {formatXP(points?.totalXp || 0)} XP
+            </div>
+
+            {showTooltip && (
+              <div
+                className={css({
+                  position: "absolute",
+                  top: "calc(100% + 8px)",
+                  right: 0,
+                  minWidth: "180px",
+                  padding: "12px 16px",
+                  background: "rgba(20, 20, 25, 0.95)",
+                  backdropFilter: "blur(10px)",
+                  borderRadius: "12px",
+                  border: "1px solid rgba(255, 255, 255, 0.1)",
+                  boxShadow: "0 8px 32px rgba(0, 0, 0, 0.4)",
+                  zIndex: 100,
+                })}
+              >
+                <div
+                  className={css({
+                    fontSize: "11px",
+                    color: "rgba(255, 255, 255, 0.6)",
+                    textTransform: "uppercase",
+                    marginBottom: "8px",
+                  })}
+                >
+                  XP Breakdown
+                </div>
+
+                <div className={css({ display: "flex", flexDirection: "column", gap: 6 })}>
+                  <div className={css({ display: "flex", justifyContent: "space-between", fontSize: "12px" })}>
+                    <span className={css({ color: "rgba(255, 255, 255, 0.8)" })}>Debt</span>
+                    <span className={css({ color: "white", fontWeight: 600 })}>{formatXP(points?.breakdown?.debt || 0)}</span>
+                  </div>
+
+                  <div className={css({ display: "flex", justifyContent: "space-between", fontSize: "12px" })}>
+                    <span className={css({ color: "rgba(255, 255, 255, 0.8)" })}>Stability</span>
+                    <span className={css({ color: "white", fontWeight: 600 })}>{formatXP(points?.breakdown?.stability || 0)}</span>
+                  </div>
+
+                  <div
+                    className={css({
+                      marginTop: "8px",
+                      paddingTop: "8px",
+                      borderTop: "1px solid rgba(255, 255, 255, 0.1)",
+                      display: "flex",
+                      justifyContent: "space-between",
+                      fontSize: "13px",
+                    })}
+                  >
+                    <span className={css({ color: "white", fontWeight: 600 })}>Total</span>
+                    <span className={css({ color: "white", fontWeight: 700 })}>{formatXP(points?.totalXp || 0)} XP</span>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      }}
+    </ConnectKitButton.Custom>
+  );
+}

--- a/frontend/app/src/comps/AppLayout/TopBar.tsx
+++ b/frontend/app/src/comps/AppLayout/TopBar.tsx
@@ -12,6 +12,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { AccountButton } from "./AccountButton";
 import { MenuDrawerButton } from "./MenuDrawer";
+import { PointsBadge } from "./PointsBadge";
 
 export function TopBar() {
   const headerConfig = useWhiteLabelHeader();
@@ -205,6 +206,7 @@ export function TopBar() {
             >
               <MenuDrawerButton menuItems={menuItems} />
             </div>
+            <PointsBadge />
             <AccountButton />
           </div>
         </div>

--- a/frontend/app/src/constants.ts
+++ b/frontend/app/src/constants.ts
@@ -54,6 +54,7 @@ export const SP_YIELD_SPLIT = 75n * 10n ** 16n; // 75%
 
 export const DATA_REFRESH_INTERVAL = 30_000;
 export const PRICE_REFRESH_INTERVAL = 60_000;
+export const POINTS_API_URL = "https://mustang-points-production.up.railway.app";
 export const DATA_STALE_TIME = 5_000;
 
 export const LEVERAGE_MAX_SLIPPAGE = 0.05; // 5%

--- a/frontend/app/src/formatting.ts
+++ b/frontend/app/src/formatting.ts
@@ -264,3 +264,9 @@ export function formatDuration(durationInSeconds: number | bigint) {
     seconds ? `${seconds}s` : null,
   ].filter(Boolean).join(" ");
 }
+
+export function formatXP(xp: number): string {
+  if (xp >= 1000000) return `${(xp / 1000000).toFixed(1)}M`;
+  if (xp >= 1000) return `${(xp / 1000).toFixed(1)}K`;
+  return xp.toLocaleString();
+}

--- a/frontend/app/src/services/Points.tsx
+++ b/frontend/app/src/services/Points.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import type { UseQueryResult } from "@tanstack/react-query";
+
+import { POINTS_API_URL } from "@/src/constants";
+import { useQuery } from "@tanstack/react-query";
+
+export type UserPoints = {
+  address: string;
+  totalXp: number;
+  breakdown: {
+    debt: number;
+    stability: number;
+  };
+  updatedAt: string;
+};
+
+async function fetchUserPoints(address: string): Promise<UserPoints | null> {
+  try {
+    const res = await fetch(`${POINTS_API_URL}/api/points/${address}`);
+    if (!res.ok) return null;
+    return res.json();
+  } catch {
+    return null;
+  }
+}
+
+export function useUserPoints(
+  address: string | null | undefined,
+): UseQueryResult<UserPoints | null> {
+  return useQuery({
+    queryKey: ["user-points", address],
+    queryFn: () => fetchUserPoints(address!),
+    enabled: !!address,
+    staleTime: 1000 * 60 * 60,
+    gcTime: 1000 * 60 * 60 * 24,
+  });
+}


### PR DESCRIPTION
I separated the Points System into its own dedicated backend service (currently hosted on Railway) rather than keeping it inside this Next.js monorepo.

- The stateful backend is hosted separately via Railway. It handles event indexing, heavy calculation, and daily snapshots.
- The stateless frontend just displays the score via PointsBadge
- The frontend fetches normalized JSON from the API endpoint.
This ensures reliability for long-running retro-active calculations and easy scalability.

You can read more about [here](https://github.com/ardey26/mustang-points)

Once merged, I will hand over the codebase to this GitHub organization for visibility